### PR TITLE
Dev changes for fixing coordinates and waiting for download

### DIFF
--- a/src/UnifiWebhookEventReceiver.cs
+++ b/src/UnifiWebhookEventReceiver.cs
@@ -135,10 +135,10 @@ namespace UnifiWebhookEventReceiver
         static int ARCHIVE_BUTTON_Y = int.TryParse(Environment.GetEnvironmentVariable("ArchiveButtonY"), out var archiveY) ? archiveY : 257;
 
         /// <summary>X coordinate for download button click. Defaults to 1095.</summary>
-        static int DOWNLOAD_BUTTON_X = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonX"), out var downloadX) ? downloadX : 1095;
+        static int DOWNLOAD_BUTTON_X = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonX"), out var downloadX) ? downloadX : 1270;
 
         /// <summary>Y coordinate for download button click. Defaults to 275.</summary>
-        static int DOWNLOAD_BUTTON_Y = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonY"), out var downloadY) ? downloadY : 275;
+        static int DOWNLOAD_BUTTON_Y = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonY"), out var downloadY) ? downloadY : 298;
 
         /// <summary>AWS region for S3 operations</summary>
         static RegionEndpoint AWS_REGION = RegionEndpoint.USEast1;

--- a/src/UnifiWebhookEventReceiver.cs
+++ b/src/UnifiWebhookEventReceiver.cs
@@ -54,6 +54,11 @@ namespace UnifiWebhookEventReceiver
     /// - UnifiHost: Hostname or IP of Unifi Protect system
     /// - UnifiUsername: Username for Unifi Protect authentication
     /// - UnifiPassword: Password for Unifi Protect authentication
+    /// - DownloadDirectory: Directory for temporary video files (defaults to /tmp)
+    /// - ArchiveButtonX: X coordinate for archive button click (defaults to 1274)
+    /// - ArchiveButtonY: Y coordinate for archive button click (defaults to 257)
+    /// - DownloadButtonX: X coordinate for download button click (defaults to 1095)
+    /// - DownloadButtonY: Y coordinate for download button click (defaults to 275)
     /// 
     /// Dependencies:
     /// - For local development, ensure PuppeteerSharp can download browser or provide custom path
@@ -122,6 +127,18 @@ namespace UnifiWebhookEventReceiver
 
         /// <summary>Download directory for temporary video files. Defaults to /tmp for Lambda compatibility.</summary>
         static string DOWNLOAD_DIRECTORY = Environment.GetEnvironmentVariable("DownloadDirectory") ?? "/tmp";
+
+        /// <summary>X coordinate for archive button click. Defaults to 1274.</summary>
+        static int ARCHIVE_BUTTON_X = int.TryParse(Environment.GetEnvironmentVariable("ArchiveButtonX"), out var archiveX) ? archiveX : 1274;
+
+        /// <summary>Y coordinate for archive button click. Defaults to 257.</summary>
+        static int ARCHIVE_BUTTON_Y = int.TryParse(Environment.GetEnvironmentVariable("ArchiveButtonY"), out var archiveY) ? archiveY : 257;
+
+        /// <summary>X coordinate for download button click. Defaults to 1095.</summary>
+        static int DOWNLOAD_BUTTON_X = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonX"), out var downloadX) ? downloadX : 1095;
+
+        /// <summary>Y coordinate for download button click. Defaults to 275.</summary>
+        static int DOWNLOAD_BUTTON_Y = int.TryParse(Environment.GetEnvironmentVariable("DownloadButtonY"), out var downloadY) ? downloadY : 275;
 
         /// <summary>AWS region for S3 operations</summary>
         static RegionEndpoint AWS_REGION = RegionEndpoint.USEast1;
@@ -929,15 +946,13 @@ namespace UnifiWebhookEventReceiver
             }
 
             //Create a dictionary of coordinates for clicks to download videos
-            int archiveButtonX = 1205;
-            int archiveButtonY = 245;
-            int downloadButtonX = 1095;
-            int downloadButtonY = 275;
             Dictionary<string, (int x, int y)> clickCoordinates = new Dictionary<string, (int x, int y)>
             {
-                { "archiveButton", (archiveButtonX, archiveButtonY) },
-                { "downloadButton", (downloadButtonX, downloadButtonY) }
+                { "archiveButton", (ARCHIVE_BUTTON_X, ARCHIVE_BUTTON_Y) },
+                { "downloadButton", (DOWNLOAD_BUTTON_X, DOWNLOAD_BUTTON_Y) }
             };
+
+            log.LogLine($"Using click coordinates - Archive: ({ARCHIVE_BUTTON_X}, {ARCHIVE_BUTTON_Y}), Download: ({DOWNLOAD_BUTTON_X}, {DOWNLOAD_BUTTON_Y})");
 
             try
             {

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -80,11 +80,11 @@ Parameters:
   DownloadButtonX:
     Type: Number
     Description: X coordinate for download button click in Unifi Protect UI
-    Default: 1095
+    Default: 1270
   DownloadButtonY:
     Type: Number
     Description: Y coordinate for download button click in Unifi Protect UI
-    Default: 275
+    Default: 298
 
 # Resources
 Resources: 
@@ -342,7 +342,7 @@ Resources:
               #AssemblyName::NameSpace.ClassName::FunctionHandlerName
       Handler: UnifiWebhookEventReceiver::UnifiWebhookEventReceiver.UnifiWebhookEventReceiver::FunctionHandler
       MemorySize: 2056
-      Timeout: 90
+      Timeout: 150
       Runtime: dotnet8
       Role: !GetAtt LambdaRole.Arn
       Environment:

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -69,6 +69,22 @@ Parameters:
     Type: String
     Description: Directory path for temporary video downloads (defaults to /tmp for Lambda compatibility)
     Default: "/tmp"
+  ArchiveButtonX:
+    Type: Number
+    Description: X coordinate for archive button click in Unifi Protect UI
+    Default: 1274
+  ArchiveButtonY:
+    Type: Number
+    Description: Y coordinate for archive button click in Unifi Protect UI
+    Default: 257
+  DownloadButtonX:
+    Type: Number
+    Description: X coordinate for download button click in Unifi Protect UI
+    Default: 1095
+  DownloadButtonY:
+    Type: Number
+    Description: Y coordinate for download button click in Unifi Protect UI
+    Default: 275
 
 # Resources
 Resources: 
@@ -326,7 +342,7 @@ Resources:
               #AssemblyName::NameSpace.ClassName::FunctionHandlerName
       Handler: UnifiWebhookEventReceiver::UnifiWebhookEventReceiver.UnifiWebhookEventReceiver::FunctionHandler
       MemorySize: 2056
-      Timeout: 180
+      Timeout: 90
       Runtime: dotnet8
       Role: !GetAtt LambdaRole.Arn
       Environment:
@@ -345,6 +361,10 @@ Resources:
           UnifiUsername: !Ref UnifiUsername
           UnifiPassword: !Ref UnifiPassword
           DownloadDirectory: !Ref DownloadDirectory
+          ArchiveButtonX: !Ref ArchiveButtonX
+          ArchiveButtonY: !Ref ArchiveButtonY
+          DownloadButtonX: !Ref DownloadButtonX
+          DownloadButtonY: !Ref DownloadButtonY
       Tags: 
         - Key: "FunctionName"
           Value: !Sub "${FunctionName}"


### PR DESCRIPTION
This pull request adds configurability for UI click coordinates used in the headless video download workflow and updates related infrastructure and code to support these new parameters. It also reduces the Lambda function timeout to better align with expected execution times.

Configuration enhancements:

* Added new environment variables (`ArchiveButtonX`, `ArchiveButtonY`, `DownloadButtonX`, `DownloadButtonY`) to allow customization of the UI click coordinates for archive and download actions in the Unifi Protect UI, with updated defaults. These are now documented and used throughout the codebase. [[1]](diffhunk://#diff-91477b271b5da6ef3c3337f1145ecb6e19eb59a59462d3e603020e4a9e443a7cR57-R61) [[2]](diffhunk://#diff-91477b271b5da6ef3c3337f1145ecb6e19eb59a59462d3e603020e4a9e443a7cR131-R142) [[3]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R72-R87) [[4]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R364-R367)
* Updated the click coordinate logic in `GetVideoFromLocalUnifiProtectViaHeadlessClient` to use the new configurable variables and added logging for the selected coordinates.

Infrastructure updates:

* Updated the CloudFormation template (`cf-stack-cs.yaml`) to include the new coordinate parameters with defaults and to pass them to the Lambda function as environment variables. [[1]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R72-R87) [[2]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R364-R367)
* Reduced the Lambda function timeout from 180 to 150 seconds to better match the expected runtime.