### PR TITLE
Fixed login on browser automation and screenshots

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,10 +73,11 @@ S3 Bucket Structure:
 │       ├── {eventId}_{deviceMac}_{timestamp}.json
 │       └── {eventId}_{deviceMac}_{timestamp}.mp4
 └── screenshots/
-    ├── login-screenshot.png
-    ├── pageload-screenshot.png
-    ├── firstclick-screenshot.png
-    └── secondclick-screenshot.png
+    └── YYYY-MM-DD/
+        ├── {eventId}_{deviceMac}_{timestamp}_login-screenshot.png
+        ├── {eventId}_{deviceMac}_{timestamp}_pageload-screenshot.png
+        ├── {eventId}_{deviceMac}_{timestamp}_firstclick-screenshot.png
+        └── {eventId}_{deviceMac}_{timestamp}_secondclick-screenshot.png
 ```
 
 ### Data Retention Policy
@@ -1177,20 +1178,25 @@ my-unifi-events-bucket/
 │   │   └── AA:BB:CC:DD:EE:FF_1704153600000.mp4
 │   └── ...
 └── screenshots/
-    ├── login-screenshot.png
-    ├── pageload-screenshot.png
-    ├── firstclick-screenshot.png
-    └── secondclick-screenshot.png
+    ├── 2024-01-01/
+    │   ├── AA:BB:CC:DD:EE:FF_1704067200000_login-screenshot.png
+    │   ├── AA:BB:CC:DD:EE:FF_1704067200000_pageload-screenshot.png
+    │   ├── AA:BB:CC:DD:EE:FF_1704067200000_firstclick-screenshot.png
+    │   ├── AA:BB:CC:DD:EE:FF_1704067200000_secondclick-screenshot.png
+    │   └── 11:22:33:44:55:66_1704070800000_login-screenshot.png
+    ├── 2024-01-02/
+    │   └── AA:BB:CC:DD:EE:FF_1704153600000_pageload-screenshot.png
+    └── ...
 ```
 
 **File Descriptions:**
 - **Event JSON files**: Webhook payload data with device mappings and timestamps
 - **Video MP4 files**: Downloaded surveillance footage corresponding to alarm events
-- **Diagnostic Screenshots**: Browser automation screenshots for debugging:
-  - `login-screenshot.png`: Unifi Protect login page state
-  - `pageload-screenshot.png`: Event page after navigation
-  - `firstclick-screenshot.png`: Archive button click state
-  - `secondclick-screenshot.png`: Download button click state
+- **Diagnostic Screenshots**: Browser automation screenshots for debugging, organized by date and event:
+  - `{eventId}_{deviceMac}_{timestamp}_login-screenshot.png`: Unifi Protect login page state
+  - `{eventId}_{deviceMac}_{timestamp}_pageload-screenshot.png`: Event page after navigation
+  - `{eventId}_{deviceMac}_{timestamp}_firstclick-screenshot.png`: Archive button click state
+  - `{eventId}_{deviceMac}_{timestamp}_secondclick-screenshot.png`: Download button click state
 
 ## Development
 

--- a/src/Infrastructure/ServiceFactory.cs
+++ b/src/Infrastructure/ServiceFactory.cs
@@ -48,7 +48,7 @@ namespace UnifiWebhookEventReceiver.Infrastructure
             var responseHelper = new ResponseHelper();
             var credentialsService = new CredentialsService(secretsClient, logger);
             var s3StorageService = new S3StorageService(s3Client, responseHelper, logger);
-            var unifiProtectService = new UnifiProtectService(logger, s3StorageService);
+            var unifiProtectService = new UnifiProtectService(logger, s3StorageService, credentialsService);
 
             // Create alarm processing service 
             var alarmProcessingService = new AlarmProcessingService(

--- a/src/Services/IS3StorageService.cs
+++ b/src/Services/IS3StorageService.cs
@@ -55,5 +55,12 @@ namespace UnifiWebhookEventReceiver.Services
         /// <param name="timestamp">The event timestamp</param>
         /// <returns>Tuple containing event key and video key</returns>
         (string eventKey, string videoKey) GenerateS3Keys(Trigger trigger, long timestamp);
+
+        /// <summary>
+        /// Uploads a screenshot file to S3 with appropriate content type.
+        /// </summary>
+        /// <param name="screenshotFilePath">Path to the local screenshot file</param>
+        /// <param name="s3Key">S3 key for the screenshot</param>
+        Task StoreScreenshotFileAsync(string screenshotFilePath, string s3Key);
     }
 }

--- a/src/Services/IUnifiProtectService.cs
+++ b/src/Services/IUnifiProtectService.cs
@@ -23,8 +23,9 @@ namespace UnifiWebhookEventReceiver.Services
         /// </summary>
         /// <param name="trigger">The trigger containing event information</param>
         /// <param name="eventLocalLink">Direct URL to the event in Unifi Protect</param>
+        /// <param name="timestamp">The event timestamp for consistent S3 key generation</param>
         /// <returns>Path to the downloaded video file</returns>
-        Task<string> DownloadVideoAsync(Trigger trigger, string eventLocalLink);
+        Task<string> DownloadVideoAsync(Trigger trigger, string eventLocalLink, long timestamp);
 
         /// <summary>
         /// Cleans up temporary video files.

--- a/src/Services/Implementations/AlarmProcessingService.cs
+++ b/src/Services/Implementations/AlarmProcessingService.cs
@@ -190,6 +190,18 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 // Download video using the Unifi Protect service
                 var tempVideoPath = await _unifiProtectService.DownloadVideoAsync(trigger, eventLocalLink);
                 _logger.LogLine($"Video downloaded to temporary file: {tempVideoPath}");
+                
+                // Verify the file exists and check its size
+                if (File.Exists(tempVideoPath))
+                {
+                    var fileInfo = new FileInfo(tempVideoPath);
+                    _logger.LogLine($"Temporary video file exists: {fileInfo.Length} bytes");
+                }
+                else
+                {
+                    _logger.LogLine($"ERROR: Temporary video file does not exist: {tempVideoPath}");
+                    return;
+                }
 
                 try
                 {
@@ -198,8 +210,14 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                     _logger.LogLine($"Generated S3 video key: {videoKey}");
 
                     // Store video in S3
+                    _logger.LogLine("About to upload video to S3...");
                     await _s3StorageService.StoreVideoFileAsync(tempVideoPath, videoKey);
-                    _logger.LogLine($"Video stored in S3 with key: {videoKey}");
+                    _logger.LogLine($"Video successfully stored in S3 with key: {videoKey}");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogLine($"ERROR uploading video to S3: {ex}");
+                    throw;
                 }
                 finally
                 {

--- a/src/Services/Implementations/AlarmProcessingService.cs
+++ b/src/Services/Implementations/AlarmProcessingService.cs
@@ -188,7 +188,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 _logger.LogLine($"Using credentials hostname: {credentials.hostname}");
 
                 // Download video using the Unifi Protect service
-                var tempVideoPath = await _unifiProtectService.DownloadVideoAsync(trigger, eventLocalLink);
+                var tempVideoPath = await _unifiProtectService.DownloadVideoAsync(trigger, eventLocalLink, alarm.timestamp);
                 _logger.LogLine($"Video downloaded to temporary file: {tempVideoPath}");
                 
                 // Verify the file exists and check its size

--- a/src/Services/Implementations/S3StorageService.cs
+++ b/src/Services/Implementations/S3StorageService.cs
@@ -74,13 +74,29 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         [ExcludeFromCodeCoverage] // Requires AWS S3 connectivity
         public async Task StoreVideoFileAsync(string videoFilePath, string s3Key)
         {
+            _logger.LogLine($"=== StoreVideoFileAsync START ===");
+            _logger.LogLine($"Video file path: {videoFilePath}");
+            _logger.LogLine($"S3 key: {s3Key}");
+            _logger.LogLine($"Bucket name: {AppConfiguration.AlarmBucketName}");
+            
             if (string.IsNullOrEmpty(AppConfiguration.AlarmBucketName))
             {
+                _logger.LogLine("ERROR: StorageBucket environment variable is not configured");
                 throw new InvalidOperationException("StorageBucket environment variable is not configured");
             }
 
+            if (!File.Exists(videoFilePath))
+            {
+                _logger.LogLine($"ERROR: Video file does not exist: {videoFilePath}");
+                throw new FileNotFoundException($"Video file not found: {videoFilePath}");
+            }
+
             var videoData = await File.ReadAllBytesAsync(videoFilePath);
+            _logger.LogLine($"Successfully read video file: {videoData.Length} bytes");
+            
+            _logger.LogLine("About to upload video data to S3...");
             await UploadBinaryContentAsync(AppConfiguration.AlarmBucketName, s3Key, videoData, "video/mp4");
+            _logger.LogLine("=== StoreVideoFileAsync END ===");
         }
 
         /// <summary>

--- a/src/Services/Implementations/S3StorageService.cs
+++ b/src/Services/Implementations/S3StorageService.cs
@@ -74,7 +74,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         [ExcludeFromCodeCoverage] // Requires AWS S3 connectivity
         public async Task StoreVideoFileAsync(string videoFilePath, string s3Key)
         {
-            _logger.LogLine($"=== StoreVideoFileAsync START ===");
             _logger.LogLine($"Video file path: {videoFilePath}");
             _logger.LogLine($"S3 key: {s3Key}");
             _logger.LogLine($"Bucket name: {AppConfiguration.AlarmBucketName}");
@@ -96,7 +95,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             
             _logger.LogLine("About to upload video data to S3...");
             await UploadBinaryContentAsync(AppConfiguration.AlarmBucketName, s3Key, videoData, "video/mp4");
-            _logger.LogLine("=== StoreVideoFileAsync END ===");
         }
 
         /// <summary>
@@ -210,7 +208,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <param name="s3Key">S3 key for the screenshot</param>
         public async Task StoreScreenshotFileAsync(string screenshotFilePath, string s3Key)
         {
-            _logger.LogLine($"=== StoreScreenshotFileAsync START ===");
             _logger.LogLine($"Screenshot file path: {screenshotFilePath}");
             _logger.LogLine($"S3 key: {s3Key}");
             _logger.LogLine($"Bucket name: {AppConfiguration.AlarmBucketName}");
@@ -243,7 +240,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             _logger.LogLine($"Using content type: {contentType}");
             _logger.LogLine("About to upload screenshot data to S3...");
             await UploadBinaryContentAsync(AppConfiguration.AlarmBucketName, s3Key, screenshotData, contentType);
-            _logger.LogLine("=== StoreScreenshotFileAsync END ===");
         }
 
         #region Private Helper Methods

--- a/src/Services/Implementations/SqsService.cs
+++ b/src/Services/Implementations/SqsService.cs
@@ -189,8 +189,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 string eventId = trigger?.eventId ?? "unknown";
                 string device = trigger?.device ?? "unknown";
 
-                _logger.LogLine($"Successfully queued alarm event {eventId} for processing in {AppConfiguration.ProcessingDelaySeconds} seconds. MessageId: {messageId}");
-
                 // Return immediate success response
                 var responseData = new
                 {

--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -25,16 +25,17 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
     public class UnifiProtectService : IUnifiProtectService
     {
         private readonly ILambdaLogger _logger;
+        private readonly IS3StorageService _s3StorageService;
 
         /// <summary>
         /// Initializes a new instance of the UnifiProtectService.
         /// </summary>
         /// <param name="logger">Lambda logger instance</param>
-        /// <param name="s3StorageService">S3 storage service for screenshot uploads (reserved for future use)</param>
+        /// <param name="s3StorageService">S3 storage service for screenshot uploads</param>
         public UnifiProtectService(ILambdaLogger logger, IS3StorageService s3StorageService)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            // s3StorageService reserved for future screenshot upload functionality
+            _s3StorageService = s3StorageService ?? throw new ArgumentNullException(nameof(s3StorageService));
         }
 
         /// <summary>
@@ -42,9 +43,10 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// </summary>
         /// <param name="trigger">The trigger containing event information</param>
         /// <param name="eventLocalLink">Direct URL to the event in Unifi Protect</param>
+        /// <param name="timestamp">The event timestamp for consistent S3 key generation</param>
         /// <returns>Path to the downloaded video file</returns>
         [ExcludeFromCodeCoverage] // Requires headless browser and external network connectivity
-        public async Task<string> DownloadVideoAsync(Trigger trigger, string eventLocalLink)
+        public async Task<string> DownloadVideoAsync(Trigger trigger, string eventLocalLink, long timestamp)
         {
             _logger.LogLine($"Starting video download for event from URL: {eventLocalLink}");
             _logger.LogLine($"Trigger details - EventId: {trigger.eventId}, Device: {trigger.device}, DeviceName: {trigger.deviceName}");
@@ -68,7 +70,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 // This would call the headless browser logic (simplified for decomposition)
                 // In the actual implementation, this would contain all the browser automation code
                 _logger.LogLine("About to call DownloadVideoFromUnifiProtect");
-                var videoData = await DownloadVideoFromUnifiProtect(eventLocalLink, trigger.deviceName ?? "", downloadDirectory);
+                var videoData = await DownloadVideoFromUnifiProtect(eventLocalLink, trigger.deviceName ?? "", downloadDirectory, trigger, timestamp);
                 _logger.LogLine($"DownloadVideoFromUnifiProtect completed, received {videoData.Length} bytes");
                 
                 // Save to temporary file
@@ -122,9 +124,11 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <param name="eventLocalLink">Direct URL to the event in Unifi Protect web interface</param>
         /// <param name="deviceName">Name of the device to determine appropriate click coordinates</param>
         /// <param name="downloadDirectory">Directory to use for downloads</param>
+        /// <param name="trigger">The trigger information for screenshot naming</param>
+        /// <param name="timestamp">The event timestamp for screenshot naming</param>
         /// <returns>Byte array containing the downloaded video data</returns>
         [ExcludeFromCodeCoverage] // Requires headless browser and external network connectivity
-        private async Task<byte[]> DownloadVideoFromUnifiProtect(string eventLocalLink, string deviceName, string downloadDirectory)
+        private async Task<byte[]> DownloadVideoFromUnifiProtect(string eventLocalLink, string deviceName, string downloadDirectory, Trigger trigger, long timestamp)
         {
             try
             {
@@ -136,15 +140,15 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 await ConfigureDownloadBehavior(page, downloadDirectory);
 
                 // Navigate to the event link and handle authentication
-                await NavigateAndAuthenticate(page, eventLocalLink, downloadDirectory);
+                await NavigateAndAuthenticate(page, eventLocalLink, downloadDirectory, trigger, timestamp);
 
                 // Wait for page to be ready for interaction and get the event handler for cleanup
-                var downloadEventHandler = await WaitForPageReady(page, downloadDirectory);
+                var downloadEventHandler = await WaitForPageReady(page, downloadDirectory, trigger, timestamp);
 
                 try
                 {
                     // Perform video download actions
-                    await PerformVideoDownloadActions(page, deviceName, downloadDirectory);
+                    await PerformVideoDownloadActions(page, deviceName, downloadDirectory, trigger, timestamp);
 
                     // Wait for download to complete and return video data
                     return await WaitForDownloadAndGetVideoData(downloadDirectory);
@@ -317,7 +321,9 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <param name="page">The browser page</param>
         /// <param name="eventLocalLink">The event URL</param>
         /// <param name="downloadDirectory">Download directory for screenshots</param>
-        private async Task NavigateAndAuthenticate(IPage page, string eventLocalLink, string downloadDirectory)
+        /// <param name="trigger">The trigger information for screenshot naming</param>
+        /// <param name="timestamp">The event timestamp for screenshot naming</param>
+        private async Task NavigateAndAuthenticate(IPage page, string eventLocalLink, string downloadDirectory, Trigger trigger, long timestamp)
         {
             _logger.LogLine($"Navigating to Unifi Protect: {eventLocalLink}");
 
@@ -333,10 +339,20 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var usernameField = await page.QuerySelectorAsync("input[name='username'], input[type='email'], input[id*='username'], input[id*='email']");
             var passwordField = await page.QuerySelectorAsync("input[name='password'], input[type='password'], input[id*='password']");
 
-            // Take a screenshot of the page (simplified - would normally upload to S3)
+            // Take a screenshot of the page and upload to S3
             var screenshotPath = Path.Combine(downloadDirectory, "login-screenshot.png");
             await page.ScreenshotAsync(screenshotPath);
             _logger.LogLine($"Screenshot taken: {screenshotPath}");
+            
+            // Upload screenshot to S3
+            await UploadScreenshotToS3(screenshotPath, "login-screenshot.png", trigger, timestamp);
+            
+            // Clean up local screenshot file
+            if (File.Exists(screenshotPath))
+            {
+                File.Delete(screenshotPath);
+                _logger.LogLine($"Local screenshot file deleted: {screenshotPath}");
+            }
 
             // Check if username and password fields are present
             if (usernameField != null && passwordField != null)
@@ -352,8 +368,10 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// </summary>
         /// <param name="page">The browser page</param>
         /// <param name="downloadDirectory">Download directory for screenshots</param>
+        /// <param name="trigger">The trigger information for screenshot naming</param>
+        /// <param name="timestamp">The event timestamp for screenshot naming</param>
         /// <returns>The download event handler that was attached</returns>
-        private async Task<EventHandler<MessageEventArgs>?> WaitForPageReady(IPage page, string downloadDirectory)
+        private async Task<EventHandler<MessageEventArgs>?> WaitForPageReady(IPage page, string downloadDirectory, Trigger trigger, long timestamp)
         {
             _logger.LogLine("Waiting for page to load after authentication...");
 
@@ -391,11 +409,21 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
 
             page.Client.MessageReceived += downloadEventHandler;
 
-            // Take a screenshot
+            // Take a screenshot and upload to S3
             await Task.Delay(3000);
             var screenshotPath = Path.Combine(downloadDirectory, "pageload-screenshot.png");
             await page.ScreenshotAsync(screenshotPath);
             _logger.LogLine($"Screenshot taken of the loaded page: {screenshotPath}");
+            
+            // Upload screenshot to S3
+            await UploadScreenshotToS3(screenshotPath, "pageload-screenshot.png", trigger, timestamp);
+            
+            // Clean up local screenshot file
+            if (File.Exists(screenshotPath))
+            {
+                File.Delete(screenshotPath);
+                _logger.LogLine($"Local screenshot file deleted: {screenshotPath}");
+            }
 
             return downloadEventHandler;
         }
@@ -406,7 +434,9 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <param name="page">The browser page</param>
         /// <param name="deviceName">Device name for coordinate calculation</param>
         /// <param name="downloadDirectory">Download directory for screenshots</param>
-        private async Task PerformVideoDownloadActions(IPage page, string deviceName, string downloadDirectory)
+        /// <param name="trigger">The trigger information for screenshot naming</param>
+        /// <param name="timestamp">The event timestamp for screenshot naming</param>
+        private async Task PerformVideoDownloadActions(IPage page, string deviceName, string downloadDirectory, Trigger trigger, long timestamp)
         {
             var coordinates = GetDeviceSpecificCoordinates(deviceName);
             
@@ -425,6 +455,16 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var screenshotPath = Path.Combine(downloadDirectory, "firstclick-screenshot.png");
             await page.ScreenshotAsync(screenshotPath);
             _logger.LogLine($"Screenshot taken of the clicked archive button: {screenshotPath}");
+            
+            // Upload screenshot to S3
+            await UploadScreenshotToS3(screenshotPath, "firstclick-screenshot.png", trigger, timestamp);
+            
+            // Clean up local screenshot file
+            if (File.Exists(screenshotPath))
+            {
+                File.Delete(screenshotPath);
+                _logger.LogLine($"Local screenshot file deleted: {screenshotPath}");
+            }
 
             // Click download button
             await page.Mouse.ClickAsync(clickCoordinates["downloadButton"].x, clickCoordinates["downloadButton"].y);
@@ -432,6 +472,17 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
 
             screenshotPath = Path.Combine(downloadDirectory, "secondclick-screenshot.png");
             await page.ScreenshotAsync(screenshotPath);
+            _logger.LogLine($"Screenshot taken of the clicked download button: {screenshotPath}");
+            
+            // Upload screenshot to S3
+            await UploadScreenshotToS3(screenshotPath, "secondclick-screenshot.png", trigger, timestamp);
+            
+            // Clean up local screenshot file
+            if (File.Exists(screenshotPath))
+            {
+                File.Delete(screenshotPath);
+                _logger.LogLine($"Local screenshot file deleted: {screenshotPath}");
+            }
             _logger.LogLine($"Screenshot taken of the clicked download button: {screenshotPath}");
         }
 
@@ -565,6 +616,48 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             return errorMessage.Contains("cannot access a disposed object") || 
                    errorMessage.Contains("disposed") ||
                    ex is ObjectDisposedException;
+        }
+
+        /// <summary>
+        /// Uploads a screenshot to S3 using consistent naming with event/video keys.
+        /// </summary>
+        /// <param name="screenshotPath">Local path to the screenshot file</param>
+        /// <param name="fileName">Base name for the file (e.g., "login-screenshot.png")</param>
+        /// <param name="trigger">The trigger information for consistent naming</param>
+        /// <param name="timestamp">The event timestamp</param>
+        private async Task UploadScreenshotToS3(string screenshotPath, string fileName, Trigger trigger, long timestamp)
+        {
+            try
+            {
+                if (!File.Exists(screenshotPath))
+                {
+                    _logger.LogLine($"Screenshot file not found for upload: {screenshotPath}");
+                    return;
+                }
+
+                // Generate S3 key using the same pattern as event and video files
+                DateTime dt = DateTimeOffset.FromUnixTimeMilliseconds(timestamp).LocalDateTime;
+                string dateFolder = $"{dt.Year}-{dt.Month:D2}-{dt.Day:D2}";
+                string basePrefix = $"{trigger.eventId}_{trigger.device}_{timestamp}";
+                
+                // Extract file extension from fileName
+                string extension = Path.GetExtension(fileName);
+                string baseName = Path.GetFileNameWithoutExtension(fileName);
+                
+                var s3Key = $"{dateFolder}/{basePrefix}_{baseName}{extension}";
+                
+                _logger.LogLine($"Uploading screenshot to S3: {s3Key}");
+                
+                // Use the existing StoreVideoFileAsync method (it works for any binary file)
+                await _s3StorageService.StoreVideoFileAsync(screenshotPath, s3Key);
+                
+                _logger.LogLine($"Screenshot successfully uploaded to S3: {s3Key}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogLine($"Error uploading screenshot to S3: {ex.Message}");
+                // Don't throw - screenshot upload failure shouldn't break the main process
+            }
         }
 
         #endregion

--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -635,7 +635,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                     return;
                 }
 
-                // Generate S3 key using the same pattern as event and video files
+                // Generate S3 key for screenshots in the screenshots folder with date subfolder
                 DateTime dt = DateTimeOffset.FromUnixTimeMilliseconds(timestamp).LocalDateTime;
                 string dateFolder = $"{dt.Year}-{dt.Month:D2}-{dt.Day:D2}";
                 string basePrefix = $"{trigger.eventId}_{trigger.device}_{timestamp}";
@@ -644,12 +644,12 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 string extension = Path.GetExtension(fileName);
                 string baseName = Path.GetFileNameWithoutExtension(fileName);
                 
-                var s3Key = $"{dateFolder}/{basePrefix}_{baseName}{extension}";
+                var s3Key = $"screenshots/{dateFolder}/{basePrefix}_{baseName}{extension}";
                 
                 _logger.LogLine($"Uploading screenshot to S3: {s3Key}");
                 
-                // Use the existing StoreVideoFileAsync method (it works for any binary file)
-                await _s3StorageService.StoreVideoFileAsync(screenshotPath, s3Key);
+                // Use the screenshot-specific upload method with proper content type
+                await _s3StorageService.StoreScreenshotFileAsync(screenshotPath, s3Key);
                 
                 _logger.LogLine($"Screenshot successfully uploaded to S3: {s3Key}");
             }

--- a/src/UnifiWebhookEventHandler.cs
+++ b/src/UnifiWebhookEventHandler.cs
@@ -166,7 +166,7 @@ namespace UnifiWebhookEventReceiver
             var responseHelper = new ResponseHelper();
             var credentialsService = new CredentialsService(secretsClient, logger);
             var s3StorageService = new S3StorageService(s3Client, responseHelper, logger);
-            var unifiProtectService = new UnifiProtectService(logger, s3StorageService);
+            var unifiProtectService = new UnifiProtectService(logger, s3StorageService, credentialsService);
             
             // Create services with resolved dependencies
             var alarmProcessingService = new AlarmProcessingService(s3StorageService, unifiProtectService, credentialsService, responseHelper, logger);
@@ -190,7 +190,7 @@ namespace UnifiWebhookEventReceiver
             var responseHelper = new ResponseHelper();
             var credentialsService = new CredentialsService(secretsClient, logger);
             var s3StorageService = new S3StorageService(s3Client, responseHelper, logger);
-            var unifiProtectService = new UnifiProtectService(logger, s3StorageService);
+            var unifiProtectService = new UnifiProtectService(logger, s3StorageService, credentialsService);
             
             // Create services with resolved dependencies
             var alarmProcessingService = new AlarmProcessingService(s3StorageService, unifiProtectService, credentialsService, responseHelper, logger);
@@ -205,7 +205,6 @@ namespace UnifiWebhookEventReceiver
         /// </summary>
         private static async Task<APIGatewayProxyResponse> ProcessSQSEventWithLogger(string requestBody, ISqsService sqsService, ILambdaLogger logger)
         {
-            logger.LogLine("=== ProcessSQSEvent START ===");
             logger.LogLine($"Request body null/empty: {string.IsNullOrEmpty(requestBody)}");
             
             if (string.IsNullOrEmpty(requestBody))


### PR DESCRIPTION
This pull request introduces significant improvements to how diagnostic screenshots are handled, stored, and documented in the Unifi Protect event processing system. It adds screenshot upload functionality to S3 with consistent naming and organization by event and date, enhances documentation to reflect these changes, and strengthens error handling and logging throughout the video and screenshot upload process. Additionally, it ensures credentials are securely retrieved for authentication during browser automation.

**Screenshot management and S3 integration:**

* Added `StoreScreenshotFileAsync` method to `IS3StorageService` and its implementation, enabling uploading of screenshots to S3 with proper content type and error handling. [[1]](diffhunk://#diff-0f242b6c1e375b0d84b991aa70adc4d1e7ac703938246e1cec950dc20e0516e6R58-R64) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R204-R244)
* Updated screenshot file naming and S3 organization: screenshots are now stored in date-based folders with names including event ID, device MAC, and timestamp for traceability. Documentation and code reflect this structure. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L76-R80) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L1180-R1199)
* Integrated screenshot uploads into the browser automation workflow: after taking each screenshot (e.g., at login), the file is uploaded to S3 and then deleted locally to save space.

**Video download and upload improvements:**

* Enhanced the video download and upload pipeline to include detailed logging, file existence checks, and error handling before attempting S3 uploads. [[1]](diffhunk://#diff-137d785cc63782c4ff01123641889744b49be0ba0753e4922a47c115e7809f1fL191-R220) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R77-R96)
* Updated method signatures throughout the video download process to pass the event timestamp, ensuring consistent S3 key generation and screenshot naming. [[1]](diffhunk://#diff-971784fbb0c49c3dad8ac99a379a6b050ae49d33d95238831c5dd77f06d38b9eR26-R28) [[2]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375R28-R52) [[3]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L71-R76) [[4]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375R130-R134) [[5]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L139-R154) [[6]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L320-R329)

**Authentication and credentials handling:**

* Improved authentication in browser automation: credentials are now securely retrieved from AWS Secrets Manager via the injected `ICredentialsService`, and the login form is programmatically filled and submitted.
* Updated service instantiation and constructors to require the credentials service where needed. [[1]](diffhunk://#diff-63bf7680d02ff977a4b69a2d3ac785f0f66d94b88afc4511c2d95f8f19b1b476L51-R51) [[2]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375R28-R52)

**Documentation updates:**

* Revised the S3 bucket structure and file description sections in `readme.md` to document the new screenshot organization and naming conventions. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L76-R80) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L1180-R1199)

**Additional improvements:**

* Strengthened and clarified logging throughout the affected services to aid in debugging and operational transparency. [[1]](diffhunk://#diff-137d785cc63782c4ff01123641889744b49be0ba0753e4922a47c115e7809f1fL191-R220) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R77-R96) [[3]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R204-R244) [[4]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L336-R422)