### PR TITLE
Refine login button selector and remove debug log

### DIFF
--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -384,7 +384,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 _logger.LogLine("Password field filled");
                 
                 // Look for login button and submit
-                var loginButton = await page.QuerySelectorAsync("button[type='submit'], input[type='submit'], button:contains('Login'), button:contains('Sign In')");
+                var loginButton = await page.QuerySelectorAsync("button[type='submit']");
                 if (loginButton != null)
                 {
                     _logger.LogLine("Clicking login button...");

--- a/src/UnifiWebhookEventHandler.cs
+++ b/src/UnifiWebhookEventHandler.cs
@@ -233,7 +233,6 @@ namespace UnifiWebhookEventReceiver
                 };
             }
 
-            logger.LogLine("Detected SQS event, processing delayed alarm");
             return await sqsService.ProcessSqsEventAsync(requestBody);
         }
 


### PR DESCRIPTION
Updated the login button selector in UnifiProtectService to only target 'button[type=submit]' for more precise element selection. Removed an unnecessary debug log line from UnifiWebhookEventHandler related to SQS event processing.