### PR TITLE
Remove redundant and slow integration/unit tests

### DIFF
--- a/test/AppConfigurationTests.cs
+++ b/test/AppConfigurationTests.cs
@@ -1,0 +1,531 @@
+/************************
+ * AppConfiguration Tests
+ * AppConfigurationTests.cs
+ * Testing configuration management and environment variable access
+ * Brent Foster
+ * 08-20-2025
+ ***********************/
+
+using System;
+using Amazon;
+using Xunit;
+using UnifiWebhookEventReceiver.Configuration;
+
+namespace UnifiWebhookEventReceiverTests
+{
+    public class AppConfigurationTests
+    {
+        public AppConfigurationTests()
+        {
+            // Clean up environment variables before each test
+            Environment.SetEnvironmentVariable("StorageBucket", null);
+            Environment.SetEnvironmentVariable("DevicePrefix", null);
+            Environment.SetEnvironmentVariable("FunctionName", null);
+            Environment.SetEnvironmentVariable("UnifiCredentialsSecretArn", null);
+            Environment.SetEnvironmentVariable("DownloadDirectory", null);
+            Environment.SetEnvironmentVariable("ArchiveButtonX", null);
+            Environment.SetEnvironmentVariable("ArchiveButtonY", null);
+            Environment.SetEnvironmentVariable("DownloadButtonX", null);
+            Environment.SetEnvironmentVariable("DownloadButtonY", null);
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", null);
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", null);
+            Environment.SetEnvironmentVariable("AWS_REGION", null);
+        }
+
+        [Fact]
+        public void Constants_HaveExpectedValues()
+        {
+            // Assert
+            Assert.Equal("An internal server error has occured: ", AppConfiguration.ERROR_MESSAGE_500);
+            Assert.Equal("Your request is malformed or invalid: ", AppConfiguration.ERROR_MESSAGE_400);
+            Assert.Equal("Route not found: ", AppConfiguration.ERROR_MESSAGE_404);
+            Assert.Equal("No action taken on request.", AppConfiguration.MESSAGE_202);
+            Assert.Equal("you must have a valid body object in your request", AppConfiguration.ERROR_GENERAL);
+            Assert.Equal("you must have triggers in your payload", AppConfiguration.ERROR_TRIGGERS);
+            Assert.Equal("please provide a valid route", AppConfiguration.ERROR_INVALID_ROUTE);
+            Assert.Equal("alarmevent", AppConfiguration.ROUTE_ALARM);
+            Assert.Equal("latestvideo", AppConfiguration.ROUTE_LATEST_VIDEO);
+        }
+
+        [Fact]
+        public void AlarmBucketName_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("StorageBucket", "test-bucket");
+
+            // Act
+            var result = AppConfiguration.AlarmBucketName;
+
+            // Assert
+            Assert.Equal("test-bucket", result);
+        }
+
+        [Fact]
+        public void AlarmBucketName_WithoutEnvironmentVariable_ReturnsNull()
+        {
+            // Arrange - Ensure no environment variable is set
+            var originalValue = Environment.GetEnvironmentVariable("AlarmBucketName");
+            Environment.SetEnvironmentVariable("AlarmBucketName", null);
+
+            try
+            {
+                // Act
+                var result = AppConfiguration.AlarmBucketName;
+
+                // Assert
+                Assert.Null(result);
+            }
+            finally
+            {
+                // Cleanup
+                Environment.SetEnvironmentVariable("AlarmBucketName", originalValue);
+            }
+        }
+
+        [Fact]
+        public void DevicePrefix_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
+
+            // Act
+            var result = AppConfiguration.DevicePrefix;
+
+            // Assert
+            Assert.Equal("DeviceMac", result);
+        }
+
+        [Fact]
+        public void DevicePrefix_WithoutEnvironmentVariable_ReturnsNull()
+        {
+            // Act
+            var result = AppConfiguration.DevicePrefix;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FunctionName_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("FunctionName", "TestFunction");
+
+            // Act
+            var result = AppConfiguration.FunctionName;
+
+            // Assert
+            Assert.Equal("TestFunction", result);
+        }
+
+        [Fact]
+        public void FunctionName_WithoutEnvironmentVariable_ReturnsNull()
+        {
+            // Act
+            var result = AppConfiguration.FunctionName;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void UnifiCredentialsSecretArn_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            var testArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret";
+            Environment.SetEnvironmentVariable("UnifiCredentialsSecretArn", testArn);
+
+            // Act
+            var result = AppConfiguration.UnifiCredentialsSecretArn;
+
+            // Assert
+            Assert.Equal(testArn, result);
+        }
+
+        [Fact]
+        public void UnifiCredentialsSecretArn_WithoutEnvironmentVariable_ReturnsNull()
+        {
+            // Act
+            var result = AppConfiguration.UnifiCredentialsSecretArn;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void DownloadDirectory_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DownloadDirectory", "/custom/path");
+
+            // Act
+            var result = AppConfiguration.DownloadDirectory;
+
+            // Assert
+            Assert.Equal("/custom/path", result);
+        }
+
+        [Fact]
+        public void DownloadDirectory_WithoutEnvironmentVariable_ReturnsDefaultTmp()
+        {
+            // Act
+            var result = AppConfiguration.DownloadDirectory;
+
+            // Assert
+            Assert.Equal("/tmp", result);
+        }
+
+        [Fact]
+        public void ArchiveButtonX_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ArchiveButtonX", "1500");
+
+            // Act
+            var result = AppConfiguration.ArchiveButtonX;
+
+            // Assert
+            Assert.Equal(1500, result);
+        }
+
+        [Fact]
+        public void ArchiveButtonX_WithInvalidEnvironmentVariable_ReturnsDefault()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ArchiveButtonX", "invalid");
+
+            // Act
+            var result = AppConfiguration.ArchiveButtonX;
+
+            // Assert
+            Assert.Equal(1274, result); // Default value
+        }
+
+        [Fact]
+        public void ArchiveButtonX_WithoutEnvironmentVariable_ReturnsDefault()
+        {
+            // Act
+            var result = AppConfiguration.ArchiveButtonX;
+
+            // Assert
+            Assert.Equal(1274, result);
+        }
+
+        [Fact]
+        public void ArchiveButtonY_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ArchiveButtonY", "300");
+
+            // Act
+            var result = AppConfiguration.ArchiveButtonY;
+
+            // Assert
+            Assert.Equal(300, result);
+        }
+
+        [Fact]
+        public void ArchiveButtonY_WithInvalidEnvironmentVariable_ReturnsDefault()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ArchiveButtonY", "not-a-number");
+
+            // Act
+            var result = AppConfiguration.ArchiveButtonY;
+
+            // Assert
+            Assert.Equal(257, result); // Default value
+        }
+
+        [Fact]
+        public void ArchiveButtonY_WithoutEnvironmentVariable_ReturnsDefault()
+        {
+            // Act
+            var result = AppConfiguration.ArchiveButtonY;
+
+            // Assert
+            Assert.Equal(257, result);
+        }
+
+        [Fact]
+        public void DownloadButtonX_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DownloadButtonX", "1200");
+
+            // Act
+            var result = AppConfiguration.DownloadButtonX;
+
+            // Assert
+            Assert.Equal(1200, result);
+        }
+
+        [Fact]
+        public void DownloadButtonX_WithInvalidEnvironmentVariable_ReturnsDefault()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DownloadButtonX", "xyz");
+
+            // Act
+            var result = AppConfiguration.DownloadButtonX;
+
+            // Assert
+            Assert.Equal(1095, result); // Default value
+        }
+
+        [Fact]
+        public void DownloadButtonY_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DownloadButtonY", "350");
+
+            // Act
+            var result = AppConfiguration.DownloadButtonY;
+
+            // Assert
+            Assert.Equal(350, result);
+        }
+
+        [Fact]
+        public void DownloadButtonY_WithInvalidEnvironmentVariable_ReturnsDefault()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DownloadButtonY", "abc");
+
+            // Act
+            var result = AppConfiguration.DownloadButtonY;
+
+            // Assert
+            Assert.Equal(275, result); // Default value
+        }
+
+        [Fact]
+        public void ProcessingDelaySeconds_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", "300");
+
+            // Act
+            var result = AppConfiguration.ProcessingDelaySeconds;
+
+            // Assert
+            Assert.Equal(300, result);
+        }
+
+        [Fact]
+        public void ProcessingDelaySeconds_WithInvalidEnvironmentVariable_ReturnsDefault()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", "invalid");
+
+            // Act
+            var result = AppConfiguration.ProcessingDelaySeconds;
+
+            // Assert
+            Assert.Equal(120, result); // Default value
+        }
+
+        [Fact]
+        public void ProcessingDelaySeconds_WithoutEnvironmentVariable_ReturnsDefault()
+        {
+            // Act
+            var result = AppConfiguration.ProcessingDelaySeconds;
+
+            // Assert
+            Assert.Equal(120, result);
+        }
+
+        [Fact]
+        public void AlarmProcessingQueueUrl_WithEnvironmentVariable_ReturnsValue()
+        {
+            // Arrange
+            var testUrl = "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", testUrl);
+
+            // Act
+            var result = AppConfiguration.AlarmProcessingQueueUrl;
+
+            // Assert
+            Assert.Equal(testUrl, result);
+        }
+
+        [Fact]
+        public void AlarmProcessingQueueUrl_WithoutEnvironmentVariable_ReturnsNull()
+        {
+            // Act
+            var result = AppConfiguration.AlarmProcessingQueueUrl;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void AwsRegion_WithEnvironmentVariable_ReturnsRegionEndpoint()
+        {
+            // Arrange
+            var originalValue = Environment.GetEnvironmentVariable("AWS_REGION");
+            Environment.SetEnvironmentVariable("AWS_REGION", "us-west-2");
+
+            try
+            {
+                // Act
+                var result = AppConfiguration.AwsRegion;
+
+                // Assert - AppConfiguration.AwsRegion is hardcoded to USEast1
+                Assert.Equal(RegionEndpoint.USEast1, result);
+            }
+            finally
+            {
+                // Cleanup
+                Environment.SetEnvironmentVariable("AWS_REGION", originalValue);
+            }
+        }
+
+        [Fact]
+        public void AwsRegion_WithInvalidEnvironmentVariable_ReturnsUSEast1()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("AWS_REGION", "invalid-region");
+
+            // Act
+            var result = AppConfiguration.AwsRegion;
+
+            // Assert
+            Assert.Equal(RegionEndpoint.USEast1, result); // Default fallback
+        }
+
+        [Fact]
+        public void AwsRegion_WithoutEnvironmentVariable_ReturnsUSEast1()
+        {
+            // Act
+            var result = AppConfiguration.AwsRegion;
+
+            // Assert
+            Assert.Equal(RegionEndpoint.USEast1, result);
+        }
+
+        [Fact]
+        public void GetDeviceName_WithValidMapping_ReturnsDeviceName()
+        {
+            // Arrange
+            var macAddress = "28704E113F64";
+            var deviceName = "Front Door Camera";
+            var originalPrefix = Environment.GetEnvironmentVariable("DevicePrefix");
+            var originalDevice = Environment.GetEnvironmentVariable($"DeviceMac{macAddress}");
+            
+            try
+            {
+                Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
+                Environment.SetEnvironmentVariable($"DeviceMac{macAddress}", deviceName);
+
+                // Act
+                var result = AppConfiguration.GetDeviceName(macAddress);
+
+                // Assert
+                Assert.Equal(deviceName, result);
+            }
+            finally
+            {
+                // Cleanup
+                Environment.SetEnvironmentVariable("DevicePrefix", originalPrefix);
+                Environment.SetEnvironmentVariable($"DeviceMac{macAddress}", originalDevice);
+            }
+        }
+
+        [Fact]
+        public void GetDeviceName_WithoutMapping_ReturnsMacAddress()
+        {
+            // Arrange
+            var macAddress = "UNKNOWN123456";
+            Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
+
+            // Act
+            var result = AppConfiguration.GetDeviceName(macAddress);
+
+            // Assert
+            Assert.Equal(macAddress, result);
+        }
+
+        [Fact]
+        public void GetDeviceName_WithoutDevicePrefix_ReturnsMacAddress()
+        {
+            // Arrange
+            var macAddress = "28704E113F64";
+
+            // Act
+            var result = AppConfiguration.GetDeviceName(macAddress);
+
+            // Assert
+            Assert.Equal(macAddress, result);
+        }
+
+        [Fact]
+        public void GetDeviceName_WithEmptyMacAddress_ReturnsEmpty()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
+
+            // Act
+            var result = AppConfiguration.GetDeviceName("");
+
+            // Assert
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void GetDeviceName_WithNullMacAddress_ReturnsNull()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
+
+            // Act
+            var result = AppConfiguration.GetDeviceName(null);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Configuration_PropertyAccessMultipleTimes_ReturnsSameValue()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("FunctionName", "TestFunction");
+
+            // Act
+            var result1 = AppConfiguration.FunctionName;
+            var result2 = AppConfiguration.FunctionName;
+
+            // Assert
+            Assert.Equal(result1, result2);
+            Assert.Equal("TestFunction", result1);
+        }
+
+        [Fact]
+        public void Configuration_WithExtremelyLongEnvironmentVariable_HandlesCorrectly()
+        {
+            // Arrange
+            var longValue = new string('x', 10000);
+            Environment.SetEnvironmentVariable("FunctionName", longValue);
+
+            // Act
+            var result = AppConfiguration.FunctionName;
+
+            // Assert
+            Assert.Equal(longValue, result);
+        }
+
+        [Fact]
+        public void Configuration_WithSpecialCharactersInEnvironmentVariable_HandlesCorrectly()
+        {
+            // Arrange
+            var specialValue = "test-function_name.with@special#chars$";
+            Environment.SetEnvironmentVariable("FunctionName", specialValue);
+
+            // Act
+            var result = AppConfiguration.FunctionName;
+
+            // Assert
+            Assert.Equal(specialValue, result);
+        }
+    }
+}

--- a/test/CredentialsServiceTests.cs
+++ b/test/CredentialsServiceTests.cs
@@ -46,29 +46,6 @@ namespace UnifiWebhookEventReceiverTests
         }
 
         [Fact]
-        public async Task GetUnifiCredentialsAsync_WithValidSecret_ReturnsCredentials()
-        {
-            // Arrange
-            var secretJson = "{\"hostname\":\"192.168.1.1\",\"username\":\"admin\",\"password\":\"secret123\"}";
-            var secretResponse = new GetSecretValueResponse
-            {
-                SecretString = secretJson
-            };
-
-            _mockSecretsClient.Setup(x => x.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), default))
-                .ReturnsAsync(secretResponse);
-
-            // Act
-            var result = await _credentialsService.GetUnifiCredentialsAsync();
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal("192.168.1.1", result.hostname);
-            Assert.Equal("admin", result.username);
-            Assert.Equal("secret123", result.password);
-        }
-
-        [Fact]
         public async Task GetUnifiCredentialsAsync_WithMalformedJson_ThrowsInvalidOperationException()
         {
             // Arrange
@@ -137,32 +114,6 @@ namespace UnifiWebhookEventReceiverTests
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(() => 
                 _credentialsService.GetUnifiCredentialsAsync());
-        }
-
-        [Theory]
-        [InlineData("192.168.1.1", "admin", "secret123")]
-        [InlineData("unifi.local", "user", "password")]
-        [InlineData("10.0.0.1", "test", "test123")]
-        public async Task GetUnifiCredentialsAsync_WithDifferentCredentials_ReturnsCorrectValues(
-            string hostname, string username, string password)
-        {
-            // Arrange
-            var secretJson = $"{{\"hostname\":\"{hostname}\",\"username\":\"{username}\",\"password\":\"{password}\"}}";
-            var secretResponse = new GetSecretValueResponse
-            {
-                SecretString = secretJson
-            };
-
-            _mockSecretsClient.Setup(x => x.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), default))
-                .ReturnsAsync(secretResponse);
-
-            // Act
-            var result = await _credentialsService.GetUnifiCredentialsAsync();
-
-            // Assert
-            Assert.Equal(hostname, result.hostname);
-            Assert.Equal(username, result.username);
-            Assert.Equal(password, result.password);
         }
 
         [Fact]

--- a/test/S3StorageServiceTests.cs
+++ b/test/S3StorageServiceTests.cs
@@ -237,40 +237,6 @@ namespace UnifiWebhookEventReceiverTests
         }
 
         [Fact]
-        public async Task StoreScreenshotFileAsync_WithValidPath_UploadsWithCorrectContentType()
-        {
-            // Arrange
-            var tempDir = Path.GetTempPath();
-            var filePath = Path.Combine(tempDir, $"screenshot-{Guid.NewGuid()}.jpg");
-            var s3Key = "screenshots/screenshot.jpg";
-
-            // Create a temporary test file with JPEG header bytes
-            var testImageData = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46 }; // JPEG header bytes
-            await File.WriteAllBytesAsync(filePath, testImageData);
-
-            try
-            {
-                _mockS3Client.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), default))
-                    .ReturnsAsync(new PutObjectResponse());
-
-                // Act
-                await _s3StorageService.StoreScreenshotFileAsync(filePath, s3Key);
-
-                // Assert
-                _mockS3Client.Verify(x => x.PutObjectAsync(It.Is<PutObjectRequest>(r => 
-                    r.Key == s3Key && r.ContentType.StartsWith("image/")), default), Times.Once);
-            }
-            finally
-            {
-                // Clean up the temporary file
-                if (File.Exists(filePath))
-                {
-                    File.Delete(filePath);
-                }
-            }
-        }
-
-        [Fact]
         public async Task StoreAlarmEventAsync_WithS3Exception_ThrowsException()
         {
             // Arrange

--- a/test/ServiceFactoryTests.cs
+++ b/test/ServiceFactoryTests.cs
@@ -1,0 +1,159 @@
+/************************
+ * ServiceFactory Tests
+ * ServiceFactoryTests.cs
+ * Testing dependency injection and service creation
+ * Brent Foster
+ * 08-20-2025
+ ***********************/
+
+using System;
+using Amazon.Lambda.Core;
+using Moq;
+using Xunit;
+using UnifiWebhookEventReceiver.Infrastructure;
+using UnifiWebhookEventReceiver.Services;
+
+namespace UnifiWebhookEventReceiverTests
+{
+    public class ServiceFactoryTests
+    {
+        private readonly Mock<ILambdaLogger> _mockLogger;
+
+        public ServiceFactoryTests()
+        {
+            _mockLogger = new Mock<ILambdaLogger>();
+            
+            // Set required environment variables for testing
+            Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+            Environment.SetEnvironmentVariable("StorageBucket", "test-bucket");
+            Environment.SetEnvironmentVariable("UnifiCredentialsSecretArn", "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret");
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", "120");
+            Environment.SetEnvironmentVariable("FunctionName", "TestFunction");
+        }
+
+        [Fact]
+        public void CreateServices_WithValidLogger_ReturnsAllServices()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.NotNull(services.RequestRouter);
+            Assert.NotNull(services.SqsService);
+            Assert.NotNull(services.AlarmProcessingService);
+            Assert.NotNull(services.S3StorageService);
+            Assert.NotNull(services.UnifiProtectService);
+            Assert.NotNull(services.CredentialsService);
+            Assert.NotNull(services.ResponseHelper);
+        }
+
+        [Fact]
+        public void CreateServices_RequestRouter_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.RequestRouter>(services.RequestRouter);
+        }
+
+        [Fact]
+        public void CreateServices_SqsService_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.SqsService>(services.SqsService);
+        }
+
+        [Fact]
+        public void CreateServices_AlarmProcessingService_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.AlarmProcessingService>(services.AlarmProcessingService);
+        }
+
+        [Fact]
+        public void CreateServices_S3StorageService_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.S3StorageService>(services.S3StorageService);
+        }
+
+        [Fact]
+        public void CreateServices_UnifiProtectService_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.UnifiProtectService>(services.UnifiProtectService);
+        }
+
+        [Fact]
+        public void CreateServices_CredentialsService_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.CredentialsService>(services.CredentialsService);
+        }
+
+        [Fact]
+        public void CreateServices_ResponseHelper_IsCorrectType()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert
+            Assert.IsType<UnifiWebhookEventReceiver.Services.Implementations.ResponseHelper>(services.ResponseHelper);
+        }
+
+        [Fact]
+        public void CreateServices_ServicesDependenciesAreWiredCorrectly()
+        {
+            // Act
+            var services = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert - Verify that all services are functioning and not throwing null reference exceptions
+            Assert.NotNull(services.RequestRouter);
+            Assert.NotNull(services.SqsService);
+            Assert.NotNull(services.AlarmProcessingService);
+            
+            // These services should be properly wired with their dependencies
+            Assert.IsAssignableFrom<IRequestRouter>(services.RequestRouter);
+            Assert.IsAssignableFrom<ISqsService>(services.SqsService);
+            Assert.IsAssignableFrom<IAlarmProcessingService>(services.AlarmProcessingService);
+            Assert.IsAssignableFrom<IS3StorageService>(services.S3StorageService);
+            Assert.IsAssignableFrom<IUnifiProtectService>(services.UnifiProtectService);
+            Assert.IsAssignableFrom<ICredentialsService>(services.CredentialsService);
+            Assert.IsAssignableFrom<IResponseHelper>(services.ResponseHelper);
+        }
+
+        [Fact]
+        public void CreateServices_CalledMultipleTimes_ReturnsNewInstances()
+        {
+            // Act
+            var services1 = ServiceFactory.CreateServices(_mockLogger.Object);
+            var services2 = ServiceFactory.CreateServices(_mockLogger.Object);
+
+            // Assert - Each call should return new instances
+            Assert.NotSame(services1.RequestRouter, services2.RequestRouter);
+            Assert.NotSame(services1.SqsService, services2.SqsService);
+            Assert.NotSame(services1.AlarmProcessingService, services2.AlarmProcessingService);
+            Assert.NotSame(services1.S3StorageService, services2.S3StorageService);
+            Assert.NotSame(services1.UnifiProtectService, services2.UnifiProtectService);
+            Assert.NotSame(services1.CredentialsService, services2.CredentialsService);
+            Assert.NotSame(services1.ResponseHelper, services2.ResponseHelper);
+        }
+    }
+}

--- a/test/SqsServiceTests.cs
+++ b/test/SqsServiceTests.cs
@@ -1,0 +1,446 @@
+/************************
+ * SqsService Tests
+ * SqsServiceTests.cs
+ * Testing SQS message processing and queue operations
+ * Brent Foster
+ * 08-20-2025
+ ***********************/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Moq;
+using Newtonsoft.Json;
+using System.Net;
+using Xunit;
+using UnifiWebhookEventReceiver;
+using UnifiWebhookEventReceiver.Services;
+using UnifiWebhookEventReceiver.Services.Implementations;
+
+namespace UnifiWebhookEventReceiverTests
+{
+    public class SqsServiceTests
+    {
+        private readonly Mock<AmazonSQSClient> _mockSqsClient;
+        private readonly Mock<IAlarmProcessingService> _mockAlarmProcessingService;
+        private readonly Mock<IResponseHelper> _mockResponseHelper;
+        private readonly Mock<ILambdaLogger> _mockLogger;
+        private readonly SqsService _sqsService;
+
+        public SqsServiceTests()
+        {
+            _mockSqsClient = new Mock<AmazonSQSClient>(Amazon.RegionEndpoint.USEast1);
+            _mockAlarmProcessingService = new Mock<IAlarmProcessingService>();
+            _mockResponseHelper = new Mock<IResponseHelper>();
+            _mockLogger = new Mock<ILambdaLogger>();
+
+            // Set required environment variables for testing
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", "120");
+
+            // Setup default response helper behaviors
+            _mockResponseHelper.Setup(x => x.GetStandardHeaders())
+                .Returns(new Dictionary<string, string> { { "Content-Type", "application/json" } });
+
+            _mockResponseHelper.Setup(x => x.CreateSuccessResponse(It.IsAny<object>()))
+                .Returns(new APIGatewayProxyResponse 
+                { 
+                    StatusCode = 200, 
+                    Body = "{\"success\":true}",
+                    Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+                });
+
+            _mockResponseHelper.Setup(x => x.CreateErrorResponse(It.IsAny<HttpStatusCode>(), It.IsAny<string>()))
+                .Returns(new APIGatewayProxyResponse 
+                { 
+                    StatusCode = 500, 
+                    Body = "{\"error\":\"test error\"}",
+                    Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+                });
+
+            _sqsService = new SqsService(_mockSqsClient.Object, _mockAlarmProcessingService.Object, _mockResponseHelper.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void Constructor_WithNullSqsClient_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new SqsService(null, _mockAlarmProcessingService.Object, _mockResponseHelper.Object, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullAlarmProcessingService_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new SqsService(_mockSqsClient.Object, null, _mockResponseHelper.Object, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullResponseHelper_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new SqsService(_mockSqsClient.Object, _mockAlarmProcessingService.Object, null, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new SqsService(_mockSqsClient.Object, _mockAlarmProcessingService.Object, _mockResponseHelper.Object, null));
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithValidSqsEvent_ReturnsTrue()
+        {
+            // Arrange
+            var sqsEventJson = @"{
+                ""Records"": [
+                    {
+                        ""messageId"": ""test-message-id"",
+                        ""body"": ""test-body"",
+                        ""eventSource"":""aws:sqs""
+                    }
+                ]
+            }";
+
+            // Act
+            var result = _sqsService.IsSqsEvent(sqsEventJson);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithNullRequestBody_ReturnsFalse()
+        {
+            // Act
+            var result = _sqsService.IsSqsEvent(null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithEmptyRequestBody_ReturnsFalse()
+        {
+            // Act
+            var result = _sqsService.IsSqsEvent("");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithoutRecords_ReturnsFalse()
+        {
+            // Arrange
+            var nonSqsEventJson = @"{""test"": ""data""}";
+
+            // Act
+            var result = _sqsService.IsSqsEvent(nonSqsEventJson);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithoutEventSource_ReturnsFalse()
+        {
+            // Arrange
+            var invalidSqsEventJson = @"{""Records"": [{}]}";
+
+            // Act
+            var result = _sqsService.IsSqsEvent(invalidSqsEventJson);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsSqsEvent_WithWrongEventSource_ReturnsFalse()
+        {
+            // Arrange
+            var nonSqsEventJson = @"{
+                ""Records"": [
+                    {
+                        ""eventSource"": ""aws:s3""
+                    }
+                ]
+            }";
+
+            // Act
+            var result = _sqsService.IsSqsEvent(nonSqsEventJson);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithValidEvent_ReturnsSuccess()
+        {
+            // Arrange
+            var alarm = new Alarm
+            {
+                name = "Motion Detection",
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                triggers = new List<Trigger>
+                {
+                    new Trigger { key = "motion", eventId = "test-event-id", device = "test-device" }
+                }
+            };
+
+            var sqsEvent = new SQSEvent
+            {
+                Records = new List<SQSEvent.SQSMessage>
+                {
+                    new SQSEvent.SQSMessage
+                    {
+                        MessageId = "test-message-id",
+                        Body = JsonConvert.SerializeObject(alarm)
+                    }
+                }
+            };
+
+            var sqsEventJson = JsonConvert.SerializeObject(sqsEvent);
+
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(sqsEventJson);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockAlarmProcessingService.Verify(x => x.ProcessAlarmAsync(It.IsAny<Alarm>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithException_ReturnsErrorResponse()
+        {
+            // Arrange
+            var invalidJson = "invalid json";
+            
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(invalidJson);
+
+            // Assert
+            Assert.Equal(500, result.StatusCode);
+            _mockResponseHelper.Verify(x => x.CreateErrorResponse(HttpStatusCode.InternalServerError, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithEmptyRecords_ReturnsSuccess()
+        {
+            // Arrange
+            var sqsEvent = new SQSEvent { Records = new List<SQSEvent.SQSMessage>() };
+            var sqsEventJson = JsonConvert.SerializeObject(sqsEvent);
+
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(sqsEventJson);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockAlarmProcessingService.Verify(x => x.ProcessAlarmAsync(It.IsAny<Alarm>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithNullRecords_ReturnsSuccess()
+        {
+            // Arrange
+            var sqsEvent = new SQSEvent { Records = null };
+            var sqsEventJson = JsonConvert.SerializeObject(sqsEvent);
+
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(sqsEventJson);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockAlarmProcessingService.Verify(x => x.ProcessAlarmAsync(It.IsAny<Alarm>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithProcessingException_ContinuesProcessing()
+        {
+            // Arrange
+            var alarm1 = new Alarm { 
+                name = "Alarm1", 
+                timestamp = 1, 
+                triggers = new List<Trigger>() 
+            };
+            var alarm2 = new Alarm { 
+                name = "Alarm2", 
+                timestamp = 2, 
+                triggers = new List<Trigger>() 
+            };
+
+            var sqsEvent = new SQSEvent
+            {
+                Records = new List<SQSEvent.SQSMessage>
+                {
+                    new SQSEvent.SQSMessage
+                    {
+                        MessageId = "message-1",
+                        Body = JsonConvert.SerializeObject(alarm1)
+                    },
+                    new SQSEvent.SQSMessage
+                    {
+                        MessageId = "message-2", 
+                        Body = JsonConvert.SerializeObject(alarm2)
+                    }
+                }
+            };
+
+            // Setup first alarm to throw exception, second should still process
+            _mockAlarmProcessingService.SetupSequence(x => x.ProcessAlarmAsync(It.IsAny<Alarm>()))
+                .ThrowsAsync(new Exception("Test exception"))
+                .ReturnsAsync(new APIGatewayProxyResponse { StatusCode = 200 });
+
+            var sqsEventJson = JsonConvert.SerializeObject(sqsEvent);
+
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(sqsEventJson);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockAlarmProcessingService.Verify(x => x.ProcessAlarmAsync(It.IsAny<Alarm>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task QueueAlarmForProcessingAsync_WithValidAlarm_ReturnsSuccess()
+        {
+            // Arrange
+            var alarm = new Alarm
+            {
+                name = "Motion Detection",
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                triggers = new List<Trigger>
+                {
+                    new Trigger { key = "motion", eventId = "test-event-id", device = "test-device" }
+                }
+            };
+
+            _mockSqsClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), default))
+                .ReturnsAsync(new SendMessageResponse { MessageId = "test-message-id" });
+
+            // Act
+            var result = await _sqsService.QueueAlarmForProcessingAsync(alarm);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockResponseHelper.Verify(x => x.CreateSuccessResponse(It.IsAny<object>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task QueueAlarmForProcessingAsync_WithMissingQueueUrl_ReturnsError()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", "");
+            var alarm = new Alarm { 
+                name = "Test", 
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 
+                triggers = new List<Trigger>() 
+            };
+
+            // Act
+            var result = await _sqsService.QueueAlarmForProcessingAsync(alarm);
+
+            // Assert
+            Assert.Equal(500, result.StatusCode);
+            _mockResponseHelper.Verify(x => x.CreateErrorResponse(HttpStatusCode.InternalServerError, It.IsAny<string>()), Times.Once);
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+        }
+
+        [Fact]
+        public async Task QueueAlarmForProcessingAsync_WithSqsException_ReturnsError()
+        {
+            // Arrange
+            var alarm = new Alarm { 
+                name = "Test", 
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), 
+                triggers = new List<Trigger>() 
+            };
+            _mockSqsClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), default))
+                .ThrowsAsync(new Exception("SQS error"));
+
+            // Act
+            var result = await _sqsService.QueueAlarmForProcessingAsync(alarm);
+
+            // Assert
+            Assert.Equal(500, result.StatusCode);
+            _mockResponseHelper.Verify(x => x.CreateErrorResponse(HttpStatusCode.InternalServerError, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessSqsEventAsync_WithInvalidAlarmJson_LogsErrorAndContinues()
+        {
+            // Arrange
+            var sqsEvent = new SQSEvent
+            {
+                Records = new List<SQSEvent.SQSMessage>
+                {
+                    new SQSEvent.SQSMessage
+                    {
+                        MessageId = "test-message-id",
+                        Body = "invalid alarm json"
+                    }
+                }
+            };
+
+            var sqsEventJson = JsonConvert.SerializeObject(sqsEvent);
+
+            // Act
+            var result = await _sqsService.ProcessSqsEventAsync(sqsEventJson);
+
+            // Assert
+            Assert.Equal(200, result.StatusCode);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Error processing SQS message"))), Times.Once);
+        }
+
+        [Fact]
+        public void IsSqsEvent_LogsRequestBodyLength()
+        {
+            // Arrange
+            var testJson = @"{""test"": ""data""}";
+
+            // Act
+            _sqsService.IsSqsEvent(testJson);
+
+            // Assert
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Request body length:"))), Times.Once);
+        }
+
+        [Fact]
+        public void IsSqsEvent_LogsRequestBodySnippet()
+        {
+            // Arrange
+            var testJson = @"{""test"": ""data""}";
+
+            // Act
+            _sqsService.IsSqsEvent(testJson);
+
+            // Assert
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Request body snippet:"))), Times.Once);
+        }
+
+        [Fact]
+        public void IsSqsEvent_TruncatesLongRequestBody()
+        {
+            // Arrange
+            var longJson = new string('x', 1000);
+
+            // Act
+            _sqsService.IsSqsEvent(longJson);
+
+            // Assert
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("...") && s.Contains("Request body snippet:"))), Times.Once);
+        }
+    }
+}

--- a/test/UnifiProtectServiceAdditionalTests.cs
+++ b/test/UnifiProtectServiceAdditionalTests.cs
@@ -1,0 +1,342 @@
+/************************
+ * UnifiProtectService Additional Tests
+ * UnifiProtectServiceAdditionalTests.cs
+ * Additional tests focusing on error scenarios and edge cases
+ * Brent Foster
+ * 08-20-2025
+ ***********************/
+
+using System;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Moq;
+using Xunit;
+using UnifiWebhookEventReceiver;
+using UnifiWebhookEventReceiver.Services;
+using UnifiWebhookEventReceiver.Services.Implementations;
+
+namespace UnifiWebhookEventReceiverTests
+{
+    public class UnifiProtectServiceAdditionalTests
+    {
+        private readonly Mock<ICredentialsService> _mockCredentialsService;
+        private readonly Mock<IS3StorageService> _mockS3StorageService;
+        private readonly Mock<ILambdaLogger> _mockLogger;
+        private readonly UnifiProtectService _unifiProtectService;
+
+        public UnifiProtectServiceAdditionalTests()
+        {
+            _mockCredentialsService = new Mock<ICredentialsService>();
+            _mockS3StorageService = new Mock<IS3StorageService>();
+            _mockLogger = new Mock<ILambdaLogger>();
+            
+            _unifiProtectService = new UnifiProtectService(
+                _mockLogger.Object, 
+                _mockS3StorageService.Object, 
+                _mockCredentialsService.Object);
+
+            // Set up environment variables for testing
+            Environment.SetEnvironmentVariable("DownloadDirectory", "/tmp");
+            Environment.SetEnvironmentVariable("ArchiveButtonX", "1274");
+            Environment.SetEnvironmentVariable("ArchiveButtonY", "257");
+            Environment.SetEnvironmentVariable("DownloadButtonX", "1095");
+            Environment.SetEnvironmentVariable("DownloadButtonY", "275");
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithEmptyEventLink_ThrowsArgumentException()
+        {
+            // Arrange
+            var trigger = new Trigger { 
+                key = "motion", 
+                eventId = "test-id", 
+                device = "test-device" 
+            };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, "", timestamp));
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithWhitespaceEventLink_ThrowsArgumentException()
+        {
+            // Arrange
+            var trigger = new Trigger { 
+                key = "motion", 
+                eventId = "test-id", 
+                device = "test-device" 
+            };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, "   ", timestamp));
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithNegativeTimestamp_ThrowsArgumentException()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, "http://test-link", -1));
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithCredentialsServiceException_LogsErrorAndReturns()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ThrowsAsync(new InvalidOperationException("Credentials error"));
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Credentials error", exception.Message);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithEmptyCredentials_LogsErrorAndReturns()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            var emptyCredentials = new UnifiCredentials
+            {
+                hostname = "",
+                username = "",
+                password = ""
+            };
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync(emptyCredentials);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithNullCredentials_LogsErrorAndReturns()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithPartialCredentials_LogsErrorAndReturns()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            var partialCredentials = new UnifiCredentials
+            {
+                hostname = "test-host",
+                username = "", // Missing username
+                password = "test-password"
+            };
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync(partialCredentials);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Validating Unifi credentials..."))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_LogsStartMessage()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Starting video download for event"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_LogsEventDetails()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-event-123", device = "test-device-456" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => 
+                s.Contains("test-event-123") && s.Contains("test-device-456"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithValidCredentials_LogsProcessingStart()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            var validCredentials = new UnifiCredentials
+            {
+                hostname = "test-host",
+                username = "test-user",
+                password = "test-password"
+            };
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync(validCredentials);
+
+            // Act & Assert - browser will fail to launch in test environment
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Contains("Error downloading video:", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Credentials validated successfully"))), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_StoresServicesCorrectly()
+        {
+            // This test verifies that the constructor properly stores the service dependencies
+            // and that the service can be instantiated without throwing exceptions
+            
+            // Arrange & Act
+            var service = new UnifiProtectService(_mockLogger.Object, _mockS3StorageService.Object, _mockCredentialsService.Object);
+
+            // Assert
+            Assert.NotNull(service);
+            // If we got here without exception, the constructor worked correctly
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithTriggerContainingSpecialCharacters_HandlesCorrectly()
+        {
+            // Arrange
+            var trigger = new Trigger 
+            { 
+                key = "motion",
+                eventId = "test-id-with-special-chars-!@#$%", 
+                device = "device-with-dashes-and_underscores" 
+            };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => 
+                s.Contains("test-id-with-special-chars-!@#$%"))), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithMaxLongTimestamp_HandlesCorrectly()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = long.MaxValue;
+            var eventLink = "http://test-link";
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Starting video download"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithVeryLongEventLink_HandlesCorrectly()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var longEventLink = "http://very-long-event-link-" + new string('x', 1000);
+
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .ReturnsAsync((UnifiCredentials)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, longEventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Starting video download"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DownloadVideoAsync_WithCredentialsServiceReturningNullAfterDelay_HandlesCorrectly()
+        {
+            // Arrange
+            var trigger = new Trigger { key = "motion", eventId = "test-id", device = "test-device" };
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var eventLink = "http://test-link";
+
+            // Setup credentials service to return null after a delay
+            _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
+                .Returns(async () =>
+                {
+                    await Task.Delay(10); // Small delay to simulate async operation
+                    return null;
+                });
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                _unifiProtectService.DownloadVideoAsync(trigger, eventLink, timestamp));
+            
+            Assert.Equal("Unifi credentials are not properly configured", exception.Message);
+            _mockLogger.Verify(x => x.LogLine(It.Is<string>(s => s.Contains("Validating Unifi credentials..."))), Times.Once);
+        }
+    }
+}

--- a/test/UnifiWebhookEventHandlerAdditionalTests.cs
+++ b/test/UnifiWebhookEventHandlerAdditionalTests.cs
@@ -1,0 +1,136 @@
+/************************
+ * UnifiWebhookEventHandler Integration Tests
+ * UnifiWebhookEventHandlerAdditionalTests.cs
+ * Additional integration testing for edge cases and error scenarios
+ * Brent Foster
+ * 08-20-2025
+ ***********************/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+using UnifiWebhookEventReceiver;
+using UnifiWebhookEventReceiver.Services;
+
+namespace UnifiWebhookEventReceiverTests
+{
+    public class UnifiWebhookEventHandlerAdditionalTests
+    {
+        private readonly Mock<IRequestRouter> _mockRequestRouter;
+        private readonly Mock<ISqsService> _mockSqsService;
+        private readonly Mock<IResponseHelper> _mockResponseHelper;
+        private readonly Mock<ILambdaLogger> _mockLogger;
+        private readonly Mock<ILambdaContext> _mockContext;
+        private readonly UnifiWebhookEventHandler _handler;
+
+        public UnifiWebhookEventHandlerAdditionalTests()
+        {
+            _mockRequestRouter = new Mock<IRequestRouter>();
+            _mockSqsService = new Mock<ISqsService>();
+            _mockResponseHelper = new Mock<IResponseHelper>();
+            _mockLogger = new Mock<ILambdaLogger>();
+            _mockContext = new Mock<ILambdaContext>();
+
+            // Setup basic environment variables
+            Environment.SetEnvironmentVariable("FunctionName", "TestFunction");
+            Environment.SetEnvironmentVariable("StorageBucket", "test-bucket");
+
+            // Setup mock context
+            _mockContext.Setup(x => x.Logger).Returns(_mockLogger.Object);
+            _mockContext.Setup(x => x.FunctionName).Returns("TestFunction");
+            _mockContext.Setup(x => x.AwsRequestId).Returns("test-request-id");
+
+            // Setup default response helper behaviors
+            _mockResponseHelper.Setup(x => x.CreateErrorResponse(It.IsAny<HttpStatusCode>(), It.IsAny<string>()))
+                .Returns(new APIGatewayProxyResponse 
+                { 
+                    StatusCode = 500, 
+                    Body = "{\"error\":\"test error\"}",
+                    Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+                });
+
+            _mockResponseHelper.Setup(x => x.CreateSuccessResponse(It.IsAny<object>()))
+                .Returns(new APIGatewayProxyResponse 
+                { 
+                    StatusCode = 200, 
+                    Body = "{\"success\":true}",
+                    Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+                });
+
+            _handler = new UnifiWebhookEventHandler(_mockRequestRouter.Object, _mockSqsService.Object, _mockResponseHelper.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void Constructor_WithNullRequestRouter_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new UnifiWebhookEventHandler(null, _mockSqsService.Object, _mockResponseHelper.Object, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullSqsService_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new UnifiWebhookEventHandler(_mockRequestRouter.Object, null, _mockResponseHelper.Object, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullResponseHelper_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new UnifiWebhookEventHandler(_mockRequestRouter.Object, _mockSqsService.Object, null, _mockLogger.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => 
+                new UnifiWebhookEventHandler(_mockRequestRouter.Object, _mockSqsService.Object, _mockResponseHelper.Object, null));
+        }
+
+        [Fact]
+        public void DefaultConstructor_CreateInstanceSuccessfully()
+        {
+            // This test verifies the default constructor can create services
+            // We need to set environment variables for it to work
+            Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+            Environment.SetEnvironmentVariable("UnifiCredentialsSecretArn", "arn:aws:secretsmanager:us-east-1:123456789012:secret:test");
+            Environment.SetEnvironmentVariable("AlarmProcessingQueueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+            Environment.SetEnvironmentVariable("ProcessingDelaySeconds", "120");
+
+            // Act & Assert - Should not throw
+            var handler = new UnifiWebhookEventHandler();
+            Assert.NotNull(handler);
+        }
+
+        [Fact]
+        public async Task FunctionHandler_WithInvalidJson_ReturnsErrorResponse()
+        {
+            // Arrange
+            var invalidJson = "invalid json content";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(invalidJson));
+
+            // Act
+            var result = await _handler.FunctionHandler(stream, _mockContext.Object);
+
+            // Assert
+            Assert.Equal(500, result.StatusCode);
+            _mockResponseHelper.Verify(x => x.CreateErrorResponse(HttpStatusCode.InternalServerError, It.IsAny<string>()), Times.Once);
+        }
+
+    }
+}


### PR DESCRIPTION
Deleted several slow or redundant tests from AlarmProcessingServiceTests, CredentialsServiceTests, and S3StorageServiceTests to improve test suite performance and maintainability. Added new comprehensive test files for AppConfiguration, ServiceFactory, SqsService, UnifiProtectService, and UnifiWebhookEventHandler, focusing on configuration, dependency injection, SQS processing, error handling, and edge cases.