### PR TITLE
Add DLQ ARN to SQS policy resources

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -155,7 +155,9 @@ Resources:
                   - sqs:ReceiveMessage
                   - sqs:DeleteMessage
                   - sqs:GetQueueUrl
-                Resource: !GetAtt AlarmProcessingQueue.Arn
+                Resource: 
+                  - !GetAtt AlarmProcessingQueue.Arn
+                  - !GetAtt AlarmProcessingDeadLetterQueue.Arn
         - PolicyName: UnifiCredentialsSecretsPolicy
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
Updated the IAM policy to include both the AlarmProcessingQueue and AlarmProcessingDeadLetterQueue ARNs in the SQS resource list, allowing access to both queues.