### PR TITLE
Added sign out to help mitigate rate limiting on sessions

### DIFF
--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -591,13 +591,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <returns>The sign out element if found, null otherwise</returns>
         private async Task<IElementHandle?> FindSignOutElement(IPage page)
         {
-            // Try direct sign out selectors first
-            var signOutElement = await TryDirectSignOutSelectors(page);
-            if (signOutElement != null)
-            {
-                return signOutElement;
-            }
-
             // If not found, try user menu approach
             return await TryUserMenuSignOut(page);
         }
@@ -612,17 +605,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var signOutSelectors = new[]
             {
                 // Specific Unifi Protect sign out button
-                "button[data-testid='LogOutButton']",
-                "button.button__7vyLR6Ac.button-light__7vyLR6Ac.width-full__7vyLR6Ac.size-medium__7vyLR6Ac.shape-default__7vyLR6Ac.fillColor-transparent-neutral__7vyLR6Ac.textColor-neutral__7vyLR6Ac.borderColor-none__7vyLR6Ac",
-                "button[data-uic-component='Button'][data-testid='LogOutButton']",
-                // Generic fallback selectors
-                "button[aria-label*='sign out' i]", "button[aria-label*='logout' i]",
-                "a[aria-label*='sign out' i]", "a[aria-label*='logout' i]",
-                "button:has-text('Sign Out')", "button:has-text('Logout')",
-                "a:has-text('Sign Out')", "a:has-text('Logout')",
-                "[data-testid*='signout']", "[data-testid*='logout']",
-                "button[title*='sign out' i]", "button[title*='logout' i]",
-                "a[title*='sign out' i]", "a[title*='logout' i]"
+                "button[data-testid='LogOutButton']"
             };
 
             foreach (var selector in signOutSelectors)
@@ -657,14 +640,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var userMenuSelectors = new[]
             {
                 // Specific Unifi Protect user avatar button
-                "button.unifi-portal-1bmvzvc.eqfginb7.button__qx3Rmpxb.button__RNxIH278.button-light__RNxIH278.large__RNxIH278.circle__RNxIH278",
-                "button.button__qx3Rmpxb.button__RNxIH278.button-light__RNxIH278.large__RNxIH278.circle__RNxIH278",
-                "button[alt*='Automated User' i]",
-                "button img[alt*='Automated User' i]",
-                // Generic fallback selectors
-                "button[aria-label*='user' i]", "button[aria-label*='profile' i]", "button[aria-label*='account' i]",
-                "[data-testid*='user']", "[data-testid*='profile']", "[data-testid*='account']",
-                ".user-menu", ".profile-menu", ".account-menu"
+                "button.unifi-portal-1bmvzvc.eqfginb7.button__qx3Rmpxb.button__RNxIH278.button-light__RNxIH278.large__RNxIH278.circle__RNxIH278"
             };
 
             foreach (var selector in userMenuSelectors)


### PR DESCRIPTION
This pull request refines the sign-out automation logic in `UnifiProtectService.cs` to improve reliability and maintainability. The main changes focus on simplifying the sign-out element search by using more specific selectors tailored to Unifi Protect, removing unused generic selectors, and cleaning up the code for clarity.

**Sign-out logic simplification and selector updates:**

* The `FindSignOutElement` method now only attempts to find the sign-out button via the user menu approach, removing the previous direct selector method for simplicity.
* The list of sign-out button selectors in `TryUserMenuSignOut` has been reduced to a single, specific selector for the Unifi Protect log out button (`button[data-testid='LogOutButton']`).
* The user menu selectors have been similarly narrowed to a specific Unifi Protect avatar button selector, removing generic alternatives.

**Code cleanup and maintainability:**

* The previously commented-out block for finding and clicking the sign-out button in `PerformSignOutAndCapture` has been removed, clarifying the intent and flow of the method. [[1]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L561) [[2]](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L573)
* Added special handling in the user menu selector loop for image-based selectors, ensuring that if an avatar image is found, its parent button is used for the sign-out process.