### PR TITLE
Preserve original video filename in event workflow

### DIFF
--- a/src/Event.cs
+++ b/src/Event.cs
@@ -106,5 +106,8 @@ namespace UnifiWebhookEventReceiver
 
         /// <summary>S3 storage key for associated video file (for future video upload functionality)</summary>
         public string? videoKey { get; set; }
+
+        /// <summary>Original filename of the downloaded video file from browser</summary>
+        public string? originalFileName { get; set; }
     }
 }

--- a/test/complexity-detailed.sh
+++ b/test/complexity-detailed.sh
@@ -5,7 +5,8 @@ echo "🔍 ENHANCED COMPLEXITY ANALYSIS 🔍"
 echo "=================================="
 echo ""
 
-cd "$(dirname "$0")"
+# Navigate to project root from test directory
+cd "$(dirname "$0")/.."
 
 echo "🏗️  Building project with analyzers..."
 dotnet build --verbosity quiet --no-restore

--- a/test/complexity-simple.sh
+++ b/test/complexity-simple.sh
@@ -4,7 +4,8 @@
 echo "🔍 CYCLOMATIC COMPLEXITY ANALYSIS 🔍"
 echo "====================================="
 
-cd "$(dirname "$0")"
+# Navigate to project root from test directory
+cd "$(dirname "$0")/.."
 
 echo "📊 Analyzing complexity in source files..."
 echo ""

--- a/test/complexity.sh
+++ b/test/complexity.sh
@@ -4,8 +4,8 @@
 echo "🔍 CYCLOMATIC COMPLEXITY ANALYSIS 🔍"
 echo "====================================="
 
-# Navigate to project root
-cd "$(dirname "$0")"
+# Navigate to project root from test directory
+cd "$(dirname "$0")/.."
 
 echo "📊 Method 1: Using SonarAnalyzer warnings..."
 echo ""

--- a/test/coverage.sh
+++ b/test/coverage.sh
@@ -3,15 +3,14 @@
 # Simple code coverage script using coverlet and XPlat
 echo "🧪 Running tests with code coverage..."
 
-# Navigate to project root
+# Navigate to test directory (script is already in test folder)
 cd "$(dirname "$0")"
 
 # Clean previous results
 rm -rf TestResults
-rm -rf test/TestResults
+rm -rf ../coverage-results
 
-# Run tests with coverage collection from test directory
-cd test
+# Run tests with coverage collection
 dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
 
 # Find the coverage file


### PR DESCRIPTION
Adds support for capturing and storing the original downloaded video filename in the event trigger and event data. Updates S3StorageService to use the original filename for downloads when available, and refactors UnifiProtectService to propagate and log the original filename throughout the video download process. Also moves shell scripts to the test directory and updates their project root navigation.