### PR TITLE
Set and restore StorageBucket env var in test

### DIFF
--- a/test/S3StorageServiceTests.cs
+++ b/test/S3StorageServiceTests.cs
@@ -376,6 +376,9 @@ namespace UnifiWebhookEventReceiverTests
         public async Task StoreScreenshotFileAsync_WithUnknownExtension_UsesDefaultContentType()
         {
             // Arrange
+            var originalBucket = Environment.GetEnvironmentVariable("StorageBucket");
+            Environment.SetEnvironmentVariable("StorageBucket", "test-bucket");
+            
             var tempScreenshotPath = Path.GetTempFileName();
             var unknownPath = Path.ChangeExtension(tempScreenshotPath, ".xyz");
             File.Move(tempScreenshotPath, unknownPath);
@@ -398,6 +401,7 @@ namespace UnifiWebhookEventReceiverTests
             {
                 if (File.Exists(unknownPath))
                     File.Delete(unknownPath);
+                Environment.SetEnvironmentVariable("StorageBucket", originalBucket);
             }
         }
 


### PR DESCRIPTION
The test StoreScreenshotFileAsync_WithUnknownExtension_UsesDefaultContentType now sets the StorageBucket environment variable to 'test-bucket' and restores its original value after the test. This ensures the test runs in a controlled environment and does not affect or depend on external configuration.