### PR TITLE
Update log message for user menu sign out

### DIFF
--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -639,8 +639,8 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <returns>The sign out element if found, null otherwise</returns>
         private async Task<IElementHandle?> TryUserMenuSignOut(IPage page)
         {
-            _logger.LogLine("Sign out button not found, trying to find user menu...");
-            
+            _logger.LogLine("Finding Sign Out button via user menu...");
+
             var userMenuSelectors = new[]
             {
                 // Specific Unifi Protect user avatar button


### PR DESCRIPTION
Revised the log message in TryUserMenuSignOut to clarify the process of finding the Sign Out button via the user menu.