### PR TITLE
Disable test parallelization in xUnit tests

### DIFF
--- a/test/DisableParallelization.cs
+++ b/test/DisableParallelization.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Adds a new assembly-level attribute to disable parallel execution of tests in the xUnit test suite. This can help avoid issues with shared state or resources during test runs.