### PR TITLE
Add configurable UniFi API metadata path support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -539,6 +539,7 @@ jobs:
               UnifiUsername="${{ secrets.UNIFI_USERNAME }}" \
               UnifiPassword="${{ secrets.UNIFI_PASSWORD }}" \
               UnifiApiKey="${{ secrets.UNIFI_API_KEY }}" \
+              UnifiApiMetadataPath="${{ secrets.UNIFI_API_METADATA_PATH }}" \
               DomainName="${{ steps.env.outputs.DOMAIN_NAME }}" \
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \

--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -170,9 +170,12 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var hostname = $"https://{domainName}";
             _logger.LogLine($"Using UniFi domain name: {hostname}");
 
-            var url = $"{hostname}/proxy/protect/api/cameras";
+            // Get the API metadata path from environment variable, with fallback to default
+            var apiMetadataPath = Environment.GetEnvironmentVariable("UnifiApiMetadataPath") ?? "/proxy/protect/api/cameras";
+            var url = $"{hostname}/{apiMetadataPath}";
             _logger.LogLine($"=== UniFi Protect API Call Details ===");
             _logger.LogLine($"Target URL: {url}");
+            _logger.LogLine($"API metadata path: {apiMetadataPath}");
             _logger.LogLine($"Original hostname from credentials: {credentials.hostname}");
             _logger.LogLine($"Final domain name: {domainName}");
             _logger.LogLine($"Deployed environment: {Environment.GetEnvironmentVariable("DeployedEnv")}");

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -75,6 +75,10 @@ Parameters:
     Type: String
     Description: Unifi Protect API key for metadata access
     NoEcho: true
+  UnifiApiMetadataPath:
+    Type: String
+    Description: Unifi Protect API metadata endpoint path
+    NoEcho: true
   DownloadDirectory:
     Type: String
     Description: Directory path for temporary video downloads (defaults to /tmp for Lambda compatibility)
@@ -609,6 +613,7 @@ Resources:
           DeviceMac28704E113F33: "Backyard West"
           DeviceMacF4E2C677E20F: "Door"
           UnifiCredentialsSecretArn: !Ref UnifiCredentialsSecret
+          UnifiApiMetadataPath: !Ref UnifiApiMetadataPath
           DownloadDirectory: !Ref DownloadDirectory
           ArchiveButtonX: !Ref ArchiveButtonX
           ArchiveButtonY: !Ref ArchiveButtonY


### PR DESCRIPTION
Introduces a new UnifiApiMetadataPath parameter in the CloudFormation template and workflow, allowing the UniFi Protect API metadata endpoint path to be set via environment variable. Updates UnifiProtectService to use this configurable path with a fallback to the default, improving deployment flexibility.