### PR TITLE
Add camera metadata endpoint and refactor metadata fetch

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -723,6 +723,12 @@ Outputs:
       - https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com/${EnvPrefix}/?eventKey={key}
       - ApiId: !Ref ApiGateway
         StageName: !Ref ApiGatewayStage
+  GETMetadataEndpoint:
+    Description: GET endpoint for fetching and storing camera metadata from Unifi Protect
+    Value: !Sub
+      - https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com/${EnvPrefix}/metadata
+      - ApiId: !Ref ApiGateway
+        StageName: !Ref ApiGatewayStage
   CustomDomainName:
     Condition: UseCustomDomain
     Description: Custom domain name for the API
@@ -739,6 +745,10 @@ Outputs:
     Condition: UseCustomDomain
     Description: GET endpoint for retrieving stored alarm event data by eventKey (Custom Domain)
     Value: !Sub "${DomainName}/${EnvPrefix}/?eventKey={key}"
+  CustomGETMetadataEndpoint:
+    Condition: UseCustomDomain
+    Description: GET endpoint for fetching and storing camera metadata from Unifi Protect (Custom Domain)
+    Value: !Sub "${DomainName}/${EnvPrefix}/metadata"
   DomainNameTarget:
     Condition: UseCustomDomain
     Description: Target domain name for DNS CNAME record

--- a/test/S3StorageServiceTests.cs
+++ b/test/S3StorageServiceTests.cs
@@ -41,7 +41,7 @@ namespace UnifiWebhookEventReceiverTests
         {
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => 
-                new S3StorageService(null, _mockResponseHelper.Object, _mockLogger.Object));
+                new S3StorageService(null!, _mockResponseHelper.Object, _mockLogger.Object));
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace UnifiWebhookEventReceiverTests
             var mockS3Client = new Mock<AmazonS3Client>(Amazon.RegionEndpoint.USEast1);
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => 
-                new S3StorageService(mockS3Client.Object, null, _mockLogger.Object));
+                new S3StorageService(mockS3Client.Object, null!, _mockLogger.Object));
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace UnifiWebhookEventReceiverTests
             var mockS3Client = new Mock<AmazonS3Client>(Amazon.RegionEndpoint.USEast1);
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => 
-                new S3StorageService(mockS3Client.Object, _mockResponseHelper.Object, null));
+                new S3StorageService(mockS3Client.Object, _mockResponseHelper.Object, null!));
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace UnifiWebhookEventReceiverTests
 
             // Act & Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => 
-                _s3StorageService.StoreAlarmEventAsync(null, trigger));
+                _s3StorageService.StoreAlarmEventAsync(null!, trigger));
         }
 
         [Fact]


### PR DESCRIPTION
Introduces a new GET /metadata endpoint for fetching and storing UniFi Protect camera metadata, updates documentation, and adds CloudFormation outputs for the new endpoint. Refactors UnifiProtectService to modularize metadata URL building and API fetching, and updates tests for nullability compliance.