### PR TITLE
Updated to use device metadata env variable passed from GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -540,7 +540,7 @@ jobs:
               UnifiPassword="${{ secrets.UNIFI_PASSWORD }}" \
               UnifiApiKey="${{ secrets.UNIFI_API_KEY }}" \
               UnifiApiMetadataPath="${{ secrets.UNIFI_API_METADATA_PATH }}" \
-              DeviceMetadata="${{ vars.DEVICE_METADATA }}" \
+              DeviceMetadata='${{ vars.DEVICE_METADATA }}' \
               DomainName="${{ steps.env.outputs.DOMAIN_NAME }}" \
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -540,6 +540,7 @@ jobs:
               UnifiPassword="${{ secrets.UNIFI_PASSWORD }}" \
               UnifiApiKey="${{ secrets.UNIFI_API_KEY }}" \
               UnifiApiMetadataPath="${{ secrets.UNIFI_API_METADATA_PATH }}" \
+              DeviceMetadata="${{ vars.DEVICE_METADATA }}" \
               DomainName="${{ steps.env.outputs.DOMAIN_NAME }}" \
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \

--- a/src/Models/DeviceMetadata.cs
+++ b/src/Models/DeviceMetadata.cs
@@ -1,0 +1,47 @@
+/************************
+ * Unifi Webhook Event Receiver
+ * DeviceMetadata.cs
+ * 
+ * Model for device metadata configuration including device mapping and UI coordinates.
+ * Represents device-specific settings loaded from environment variables.
+ * 
+ * Author: Brent Foster
+ * Created: 08-25-2025
+ ***********************/
+
+using System.Text.Json.Serialization;
+
+namespace UnifiWebhookEventReceiver.Models
+{
+    /// <summary>
+    /// Represents metadata for a Unifi Protect device including name mapping and UI coordinates.
+    /// </summary>
+    public class DeviceMetadata
+    {
+        /// <summary>Human-readable device name</summary>
+        [JsonPropertyName("deviceName")]
+        public required string DeviceName { get; set; }
+
+        /// <summary>Device MAC address identifier</summary>
+        [JsonPropertyName("deviceMac")]
+        public required string DeviceMac { get; set; }
+
+        /// <summary>X coordinate for archive button in Unifi Protect UI</summary>
+        [JsonPropertyName("archiveButtonX")]
+        public required int ArchiveButtonX { get; set; }
+
+        /// <summary>Y coordinate for archive button in Unifi Protect UI</summary>
+        [JsonPropertyName("archiveButtonY")]
+        public required int ArchiveButtonY { get; set; }
+    }
+
+    /// <summary>
+    /// Collection of device metadata entries loaded from environment configuration.
+    /// </summary>
+    public class DeviceMetadataCollection
+    {
+        /// <summary>List of device metadata entries</summary>
+        [JsonPropertyName("devices")]
+        public List<DeviceMetadata> Devices { get; set; } = new List<DeviceMetadata>();
+    }
+}

--- a/src/Services/Implementations/AlarmProcessingService.cs
+++ b/src/Services/Implementations/AlarmProcessingService.cs
@@ -263,7 +263,14 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         {
             try
             {
-                string eventLocalLink = credentials.hostname + alarm.eventPath;
+                // Ensure hostname has protocol prefix
+                string hostname = credentials.hostname;
+                if (!hostname.StartsWith("http://") && !hostname.StartsWith("https://"))
+                {
+                    hostname = "https://" + hostname;
+                }
+                
+                string eventLocalLink = hostname + alarm.eventPath;
                 _logger.LogLine($"Starting video download for event: {trigger.eventId}");
                 _logger.LogLine($"Event local link: {eventLocalLink}");
                 _logger.LogLine($"Using credentials hostname: {credentials.hostname}");

--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -393,25 +393,11 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <returns>Tuple containing archive and download button coordinates</returns>
         private static ((int x, int y) archiveButton, (int x, int y) downloadButton) GetDeviceSpecificCoordinates(string deviceName)
         {
-            // For "Door" device, use the default coordinates from environment variables
-            if (string.Equals(deviceName, "Door", StringComparison.OrdinalIgnoreCase))
-            {
-                return (
-                    archiveButton: (AppConfiguration.ArchiveButtonX, AppConfiguration.ArchiveButtonY),
-                    downloadButton: (AppConfiguration.DownloadButtonX, AppConfiguration.DownloadButtonY)
-                );
-            }
+            // Get device MAC address using the existing method
+            string? deviceMac = AppConfiguration.GetDeviceMac(deviceName);
             
-            // For all other devices, use adjusted coordinates
-            int archiveX = 1205;
-            int archiveY = 241;
-            int downloadX = archiveX - 179;  // 1205 - 179 = 1026
-            int downloadY = archiveY + 18;   // 241 + 18 = 259
-            
-            return (
-                archiveButton: (archiveX, archiveY),
-                downloadButton: (downloadX, downloadY)
-            );
+            // Use the new JSON-based configuration to get coordinates, fallback to MAC if not found by name
+            return AppConfiguration.GetDeviceCoordinates(deviceMac ?? deviceName);
         }
 
         /// <summary>

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -83,14 +83,6 @@ Parameters:
     Type: String
     Description: Directory path for temporary video downloads (defaults to /tmp for Lambda compatibility)
     Default: "/tmp"
-  ArchiveButtonX:
-    Type: Number
-    Description: X coordinate for archive button click in Unifi Protect UI
-    Default: 1274
-  ArchiveButtonY:
-    Type: Number
-    Description: Y coordinate for archive button click in Unifi Protect UI
-    Default: 257
   ProcessingDelaySeconds:
     Type: Number
     Description: Delay in seconds before processing alarm events (default 2 minutes)
@@ -109,6 +101,44 @@ Parameters:
     Type: String
     Description: Timestamp when this build was created
     Default: "unknown"
+  DeviceMetadata:
+    Type: String
+    Description: JSON configuration for device names, MAC addresses, and UI coordinates
+    Default: |
+      {
+        "Devices": [
+          {
+            "DeviceName": "Backyard East",
+            "DeviceMac": "28704E113F64",
+            "ArchiveButtonX": 1205,
+            "ArchiveButtonY": 240
+          },
+          {
+            "DeviceName": "Front",
+            "DeviceMac": "F4E2C67A2FE8",
+            "ArchiveButtonX": 1205,
+            "ArchiveButtonY": 240
+          },
+          {
+            "DeviceName": "Side",
+            "DeviceMac": "28704E113C44",
+            "ArchiveButtonX": 1205,
+            "ArchiveButtonY": 240
+          },
+          {
+            "DeviceName": "Backyard West",
+            "DeviceMac": "28704E113F33",
+            "ArchiveButtonX": 1205,
+            "ArchiveButtonY": 240
+          },
+          {
+            "DeviceName": "Door",
+            "DeviceMac": "F4E2C677E20F",
+            "ArchiveButtonX": 1275,
+            "ArchiveButtonY": 260
+          }
+        ]
+      }
   DomainName:
     Type: String
     Description: Custom domain name for the API Gateway (e.g., api.brentfoster.me)
@@ -606,17 +636,10 @@ Resources:
           DeployedEnv: !Sub "${EnvPrefix}"
           StorageBucket: !Sub "${BucketName}"
           ApiKey: !Sub "${ApiGatewayKey}"
-          DevicePrefix: "DeviceMac"
-          DeviceMac28704E113F64: "Backyard East"
-          DeviceMacF4E2C67A2FE8: "Front"
-          DeviceMac28704E113C44: "Side"
-          DeviceMac28704E113F33: "Backyard West"
-          DeviceMacF4E2C677E20F: "Door"
+          DeviceMetadata: !Ref DeviceMetadata
           UnifiCredentialsSecretArn: !Ref UnifiCredentialsSecret
           UnifiApiMetadataPath: !Ref UnifiApiMetadataPath
           DownloadDirectory: !Ref DownloadDirectory
-          ArchiveButtonX: !Ref ArchiveButtonX
-          ArchiveButtonY: !Ref ArchiveButtonY
           AlarmProcessingQueueUrl: !Ref AlarmProcessingQueue
           AlarmProcessingDlqUrl: !Ref AlarmProcessingDeadLetterQueue
           ProcessingDelaySeconds: !Ref ProcessingDelaySeconds

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -104,41 +104,7 @@ Parameters:
   DeviceMetadata:
     Type: String
     Description: JSON configuration for device names, MAC addresses, and UI coordinates
-    Default: |
-      {
-        "Devices": [
-          {
-            "DeviceName": "Backyard East",
-            "DeviceMac": "28704E113F64",
-            "ArchiveButtonX": 1205,
-            "ArchiveButtonY": 240
-          },
-          {
-            "DeviceName": "Front",
-            "DeviceMac": "F4E2C67A2FE8",
-            "ArchiveButtonX": 1205,
-            "ArchiveButtonY": 240
-          },
-          {
-            "DeviceName": "Side",
-            "DeviceMac": "28704E113C44",
-            "ArchiveButtonX": 1205,
-            "ArchiveButtonY": 240
-          },
-          {
-            "DeviceName": "Backyard West",
-            "DeviceMac": "28704E113F33",
-            "ArchiveButtonX": 1205,
-            "ArchiveButtonY": 240
-          },
-          {
-            "DeviceName": "Door",
-            "DeviceMac": "F4E2C677E20F",
-            "ArchiveButtonX": 1275,
-            "ArchiveButtonY": 260
-          }
-        ]
-      }
+    Default: "replaced from GitHub Actions variable"
   DomainName:
     Type: String
     Description: Custom domain name for the API Gateway (e.g., api.brentfoster.me)

--- a/test/AlarmProcessingServiceTests.cs
+++ b/test/AlarmProcessingServiceTests.cs
@@ -506,7 +506,7 @@ namespace UnifiWebhookEventReceiverTests
                 // Assert
                 Assert.Equal(200, result.StatusCode);
                 _mockS3StorageService.Verify(x => x.StoreAlarmEventAsync(It.IsAny<Alarm>(), It.IsAny<Trigger>()), Times.Once);
-                _mockUnifiProtectService.Verify(x => x.DownloadVideoAsync(It.IsAny<Trigger>(), credentials.hostname + alarm.eventPath, alarm.timestamp), Times.Once);
+                _mockUnifiProtectService.Verify(x => x.DownloadVideoAsync(It.IsAny<Trigger>(), "https://" + credentials.hostname + alarm.eventPath, alarm.timestamp), Times.Once);
                 _mockS3StorageService.Verify(x => x.StoreVideoFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             }
             finally


### PR DESCRIPTION
This pull request introduces a new, centralized JSON-based configuration for device metadata, replacing the legacy approach of using multiple environment variables for device names and UI coordinates. It updates the application and infrastructure to use this new configuration, adds a new model for device metadata, and ensures backward compatibility with the previous environment variable setup. Additionally, it includes a fix to ensure hostnames have the correct protocol prefix when constructing URLs.

**Device Metadata Configuration Modernization:**

- Added a new `DeviceMetadata` JSON environment variable and corresponding `DeviceMetadataCollection` and `DeviceMetadata` model classes to centralize device name, MAC address, and UI coordinate configuration. (`src/Models/DeviceMetadata.cs` [[1]](diffhunk://#diff-7c50126464baed72a02867fca74b5b5f5cbcadae536f98f4fcff0fcbd5df522aR1-R47) `.github/workflows/deploy.yml` [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R543) `templates/cf-stack-cs.yaml` [[3]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R104-R107) [[4]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158L609-L619)
- Refactored `AppConfiguration` to load and parse device metadata from the new JSON variable, providing methods for device name lookup, MAC lookup, and device-specific UI coordinates. Legacy environment variable support is retained but marked as deprecated. (`src/Configuration/AppConfiguration.cs` [[1]](diffhunk://#diff-1f96d61c4b1c39436d1811345151a3e156c742c0bff24e8b187466fe4cb2ba80R13-R14) [[2]](diffhunk://#diff-1f96d61c4b1c39436d1811345151a3e156c742c0bff24e8b187466fe4cb2ba80L61-L63) [[3]](diffhunk://#diff-1f96d61c4b1c39436d1811345151a3e156c742c0bff24e8b187466fe4cb2ba80L73-L78) [[4]](diffhunk://#diff-1f96d61c4b1c39436d1811345151a3e156c742c0bff24e8b187466fe4cb2ba80L115-R272)

**Infrastructure and Environment Variable Updates:**

- Removed legacy device name and coordinate environment variables from the CloudFormation template and replaced them with the new `DeviceMetadata` parameter. (`templates/cf-stack-cs.yaml` [[1]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158L86-L93) [[2]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158R104-R107) [[3]](diffhunk://#diff-58746adc98a136d8f5ec1b89a1fbf6dbd36dcf86e1875769e3ad1cb776801158L609-L619)

**Application Logic Improvements:**

- Updated logic in `UnifiProtectService` to resolve device-specific UI coordinates via the new JSON-based configuration, falling back to legacy methods if necessary. (`src/Services/Implementations/UnifiProtectService.cs` [src/Services/Implementations/UnifiProtectService.csL396-R400](diffhunk://#diff-8a61c3b6c8725da65cf63ca1d497362fe3acc8f6410cb577d1e6746d86a46375L396-R400))
- Updated video download logic to ensure the hostname always includes a protocol prefix (e.g., `https://`). (`src/Services/Implementations/AlarmProcessingService.cs` [src/Services/Implementations/AlarmProcessingService.csL266-R273](diffhunk://#diff-137d785cc63782c4ff01123641889744b49be0ba0753e4922a47c115e7809f1fL266-R273))
- Adjusted related unit test expectations to account for the protocol prefix in video download URLs. (`test/AlarmProcessingServiceTests.cs` [test/AlarmProcessingServiceTests.csL509-R509](diffhunk://#diff-3235dbdc523f7862e9301ae8309ae9d3b3c7739219a4657b4f8f6daffb488e80L509-R509))