### PR TITLE
Add UNIFI_HOST to deploy workflow and update device metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
             echo "LAMBDA_NAME=bf-prod-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "S3_KEY_PREFIX=bf-prod-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "DOMAIN_NAME=${{ vars.PROD_DOMAIN_NAME }}" >> $GITHUB_OUTPUT
+            echo "UNIFI_HOST=${{ secrets.PROD_UNIFI_HOST }}" >> $GITHUB_OUTPUT
             echo "HOSTED_ZONE_ID=${{ vars.HOSTED_ZONE_ID }}" >> $GITHUB_OUTPUT
           else
             echo "ENV_PREFIX=dev" >> $GITHUB_OUTPUT
@@ -50,11 +51,13 @@ jobs:
             echo "LAMBDA_NAME=bf-dev-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "S3_KEY_PREFIX=bf-dev-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "DOMAIN_NAME=${{ vars.DEV_DOMAIN_NAME }}" >> $GITHUB_OUTPUT
+            echo "UNIFI_HOST=${{ secrets.DEV_UNIFI_HOST }}" >> $GITHUB_OUTPUT
             echo "HOSTED_ZONE_ID=${{ vars.HOSTED_ZONE_ID }}" >> $GITHUB_OUTPUT
           fi
           echo "Deploying to environment: $ENV_PREFIX"
           echo "Stack name: $STACK_NAME"
           echo "Domain name: $DOMAIN_NAME"
+          echo "Unifi Host: $UNIFI_HOST"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -493,6 +496,7 @@ jobs:
             echo "LAMBDA_NAME=bf-prod-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "S3_KEY_PREFIX=bf-prod-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "DOMAIN_NAME=${{ vars.PROD_DOMAIN_NAME }}" >> $GITHUB_OUTPUT
+            echo "UNIFI_HOST=${{ secrets.PROD_UNIFI_HOST }}" >> $GITHUB_OUTPUT
             echo "HOSTED_ZONE_ID=${{ vars.HOSTED_ZONE_ID }}" >> $GITHUB_OUTPUT
           else
             echo "ENV_PREFIX=dev" >> $GITHUB_OUTPUT
@@ -502,11 +506,13 @@ jobs:
             echo "LAMBDA_NAME=bf-dev-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "S3_KEY_PREFIX=bf-dev-lambda-unifi-protect-event-backup-api" >> $GITHUB_OUTPUT
             echo "DOMAIN_NAME=${{ vars.DEV_DOMAIN_NAME }}" >> $GITHUB_OUTPUT
+            echo "UNIFI_HOST=${{ secrets.DEV_UNIFI_HOST }}" >> $GITHUB_OUTPUT
             echo "HOSTED_ZONE_ID=${{ vars.HOSTED_ZONE_ID }}" >> $GITHUB_OUTPUT
           fi
           echo "Deploying to environment: $ENV_PREFIX"
           echo "Stack name: $STACK_NAME"
           echo "Domain name: $DOMAIN_NAME"
+          echo "Unifi Host: $UNIFI_HOST"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -534,7 +540,7 @@ jobs:
               BucketNameDeployment="${{ steps.env.outputs.BUCKET_DEPLOYMENT }}" \
               FunctionName="${{ steps.env.outputs.LAMBDA_NAME }}" \
               RoleName="${{ steps.env.outputs.LAMBDA_NAME }}-role" \
-              UnifiHost="${{ secrets.UNIFI_HOST }}" \
+              UnifiHost="${{ steps.env.outputs.UNIFI_HOST }}" \
               UnifiHostIp="${{ secrets.UNIFI_HOST_IP }}" \
               UnifiUsername="${{ secrets.UNIFI_USERNAME }}" \
               UnifiPassword="${{ secrets.UNIFI_PASSWORD }}" \

--- a/readme.md
+++ b/readme.md
@@ -710,7 +710,7 @@ Fetches current camera metadata from your Unifi Protect system and stores it in 
 Device and UI coordinate mapping is now managed via a single JSON environment variable, `DeviceMetadata`, set as a GitHub repository variable and passed to CloudFormation. Example:
 
 ```
-{"Devices":[{"DeviceName":"Backyard East","DeviceMac":"28704E113F64","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Front","DeviceMac":"F4E2C67A2FE8","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Side","DeviceMac":"28704E113C44","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Backyard West","DeviceMac":"28704E113F33","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Door","DeviceMac":"F4E2C677E20F","ArchiveButtonX":1275,"ArchiveButtonY":260}]}
+{"Devices":[{"DeviceName":"Backyard East","DeviceMac":"28704EAA3F64","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Front","DeviceMac":"F4E2C6BB2FE8","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Side","DeviceMac":"28704EC13C44","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Backyard West","DeviceMac":"28704ED13F33","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Door","DeviceMac":"F4E2AB77E20F","ArchiveButtonX":1275,"ArchiveButtonY":260}]}
 ```
 
 - Set this as the `DEVICEMETADATA` GitHub repository variable.


### PR DESCRIPTION
The deploy GitHub Actions workflow now sets the UNIFI_HOST environment variable for both production and development environments, passing it from secrets to subsequent steps. The readme device metadata example has been updated with new DeviceMac values.