### PR TITLE
Remove deprecated device and coordinate config, update tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -713,7 +713,7 @@ Device and UI coordinate mapping is now managed via a single JSON environment va
 {"Devices":[{"DeviceName":"Backyard East","DeviceMac":"28704EAA3F64","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Front","DeviceMac":"F4E2C6BB2FE8","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Side","DeviceMac":"28704EC13C44","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Backyard West","DeviceMac":"28704ED13F33","ArchiveButtonX":1205,"ArchiveButtonY":240},{"DeviceName":"Door","DeviceMac":"F4E2AB77E20F","ArchiveButtonX":1275,"ArchiveButtonY":260}]}
 ```
 
-- Set this as the `DEVICEMETADATA` GitHub repository variable.
+- Set this as the `DEVICE_METADATA` GitHub repository variable.
 - The Lambda function will use this for all device name and coordinate lookups.
 
 ### ⚙️ Environment Variables (Manual Deploy)

--- a/src/Configuration/AppConfiguration.cs
+++ b/src/Configuration/AppConfiguration.cs
@@ -247,29 +247,6 @@ namespace UnifiWebhookEventReceiver.Configuration
 
         #endregion
 
-        #region Legacy Support (Deprecated)
-
-        /// <summary>
-        /// Prefix for environment variables containing device MAC to name mappings.
-        /// DEPRECATED: Use DeviceMetadata instead.
-        /// </summary>
-        [Obsolete("Use DeviceMetadata environment variable instead", false)]
-        public static string? DevicePrefix => Environment.GetEnvironmentVariable("DevicePrefix");
-
-        /// <summary>
-        /// X coordinate for archive button click. Defaults to 1274.
-        /// DEPRECATED: Use GetDeviceCoordinates instead.
-        /// </summary>
-        [Obsolete("Use GetDeviceCoordinates instead", false)]
-        public static int ArchiveButtonX => int.TryParse(Environment.GetEnvironmentVariable("ArchiveButtonX"), out var archiveX) ? archiveX : 1274;
-
-        /// <summary>
-        /// Y coordinate for archive button click. Defaults to 257.
-        /// DEPRECATED: Use GetDeviceCoordinates instead.
-        /// </summary>
-        [Obsolete("Use GetDeviceCoordinates instead", false)]
-        public static int ArchiveButtonY => int.TryParse(Environment.GetEnvironmentVariable("ArchiveButtonY"), out var archiveY) ? archiveY : 257;
-
-        #endregion
-    }
+    // Deprecated members removed. Use DeviceMetadata and GetDeviceCoordinates instead.
+}
 }

--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -159,7 +159,6 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             var s3Key = "metadata/cameras.json";
             await _s3StorageService.StoreJsonStringAsync(json, s3Key);
             _logger.LogLine($"Camera metadata stored in S3 at {s3Key}");
-            _logger.LogLine($"=== API Call Completed Successfully ===");
             
             return json;
         }
@@ -188,18 +187,10 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 
             // Always use HTTPS with the domain name
             var hostname = $"https://{domainName}";
-            _logger.LogLine($"Using UniFi domain name: {hostname}");
 
             // Get the API metadata path from environment variable, with fallback to default
             var apiMetadataPath = Environment.GetEnvironmentVariable("UnifiApiMetadataPath") ?? "/proxy/protect/api/cameras";
             var url = $"{hostname}/{apiMetadataPath}";
-            
-            _logger.LogLine($"=== UniFi Protect API Call Details ===");
-            _logger.LogLine($"Target URL: {url}");
-            _logger.LogLine($"API metadata path: {apiMetadataPath}");
-            _logger.LogLine($"Original hostname from credentials: {credentials.hostname}");
-            _logger.LogLine($"Final domain name: {domainName}");
-            _logger.LogLine($"Deployed environment: {Environment.GetEnvironmentVariable("DeployedEnv")}");
 
             return url;
         }
@@ -233,82 +224,36 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             httpClient.DefaultRequestHeaders.Add("User-Agent", "UnifiWebhookEventReceiver/1.0");
             httpClient.DefaultRequestHeaders.Add("x-api-key", credentials.apikey);
             
-            // Log request headers (mask the API key for security)
-            _logger.LogLine("=== Request Headers ===");
-            _logger.LogLine($"Accept: application/json");
-            _logger.LogLine($"User-Agent: UnifiWebhookEventReceiver/1.0");
-            _logger.LogLine($"x-api-key: {new string('*', Math.Max(0, credentials.apikey.Length - 4))}{credentials.apikey.Substring(Math.Max(0, credentials.apikey.Length - 4))}");
-
             try
             {
-                _logger.LogLine("=== Making HTTPS Request ===");
-                var startTime = DateTime.UtcNow;
                 var response = await httpClient.GetAsync(url);
-                var endTime = DateTime.UtcNow;
-                var duration = endTime - startTime;
-                
-                _logger.LogLine($"=== Response Details ===");
-                _logger.LogLine($"Request duration: {duration.TotalMilliseconds:F2} ms");
-                _logger.LogLine($"Response status code: {(int)response.StatusCode} {response.StatusCode}");
-                _logger.LogLine($"Response reason phrase: {response.ReasonPhrase ?? "null"}");
-                
-                // Log response headers
-                _logger.LogLine("=== Response Headers ===");
-                foreach (var header in response.Headers)
-                {
-                    _logger.LogLine($"{header.Key}: {string.Join(", ", header.Value)}");
-                }
-                foreach (var header in response.Content.Headers)
-                {
-                    _logger.LogLine($"{header.Key}: {string.Join(", ", header.Value)}");
-                }
 
                 if (!response.IsSuccessStatusCode)
                 {
                     var error = await response.Content.ReadAsStringAsync();
-                    _logger.LogLine($"=== Error Response ===");
                     _logger.LogLine($"Failed to fetch camera metadata: {response.StatusCode} - {response.ReasonPhrase}");
-                    _logger.LogLine($"Error content length: {error?.Length ?? 0} characters");
-                    _logger.LogLine($"Error content: {error ?? "null"}");
                     throw new InvalidOperationException($"Failed to fetch camera metadata: {response.StatusCode} - {error}");
                 }
 
                 var json = await response.Content.ReadAsStringAsync();
-                _logger.LogLine($"=== Success Response ===");
                 _logger.LogLine($"Fetched camera metadata successfully");
-                _logger.LogLine($"Response content length: {json.Length} characters");
-                _logger.LogLine($"Content type: {response.Content.Headers.ContentType?.ToString() ?? "unknown"}");
-                
-                // Log a sample of the JSON for debugging (first 200 characters)
-                var jsonSample = json.Length > 200 ? string.Concat(json.AsSpan(0, 200), "...") : json;
-                _logger.LogLine($"JSON sample: {jsonSample}");
 
                 return json;
             }
             catch (HttpRequestException httpEx)
             {
-                _logger.LogLine($"=== HTTP Request Exception ===");
                 _logger.LogLine($"Exception message: {httpEx.Message}");
-                _logger.LogLine($"Inner exception: {httpEx.InnerException?.Message ?? "null"}");
-                _logger.LogLine($"Target URL was: {url}");
-                _logger.LogLine($"Always using domain name mode for connections");
                 throw new InvalidOperationException($"Network error while fetching camera metadata: {httpEx.Message}", httpEx);
             }
             catch (TaskCanceledException tcEx)
             {
-                _logger.LogLine($"=== Request Timeout Exception ===");
                 _logger.LogLine($"Timeout exception: {tcEx.Message}");
-                _logger.LogLine($"Is cancellation requested: {tcEx.CancellationToken.IsCancellationRequested}");
-                _logger.LogLine($"Target URL was: {url}");
                 throw new InvalidOperationException("Request timed out while fetching camera metadata (30 second timeout)", tcEx);
             }
             catch (Exception ex)
             {
-                _logger.LogLine($"=== Unexpected Exception ===");
                 _logger.LogLine($"Exception type: {ex.GetType().Name}");
                 _logger.LogLine($"Exception message: {ex.Message}");
-                _logger.LogLine($"Stack trace: {ex.StackTrace}");
-                _logger.LogLine($"Target URL was: {url}");
                 throw;
             }
         }

--- a/test/AppConfigurationTests.cs
+++ b/test/AppConfigurationTests.cs
@@ -21,8 +21,8 @@ namespace UnifiWebhookEventReceiverTests
             // Don't restore them to avoid conflicts with other test classes
             var variablesToClean = new[] 
             {
-                "StorageBucket", "DevicePrefix", "FunctionName", "UnifiCredentialsSecretArn",
-                "DownloadDirectory", "ArchiveButtonX", "ArchiveButtonY", "DownloadButtonX", 
+                "StorageBucket", "FunctionName", "UnifiCredentialsSecretArn",
+                "DownloadDirectory", "DownloadButtonX", 
                 "DownloadButtonY", "ProcessingDelaySeconds", "AlarmProcessingQueueUrl", 
                 "AWS_REGION", "DeployedEnv", "BuildSha", "BuildTimestamp"
             };
@@ -104,28 +104,7 @@ namespace UnifiWebhookEventReceiverTests
             }
         }
 
-        [Fact]
-        public void DevicePrefix_WithEnvironmentVariable_ReturnsValue()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("DevicePrefix", "DeviceMac");
-
-            // Act
-            var result = AppConfiguration.DevicePrefix;
-
-            // Assert
-            Assert.Equal("DeviceMac", result);
-        }
-
-        [Fact]
-        public void DevicePrefix_WithoutEnvironmentVariable_ReturnsNull()
-        {
-            // Act
-            var result = AppConfiguration.DevicePrefix;
-
-            // Assert
-            Assert.Null(result);
-        }
+        // DevicePrefix tests removed: DevicePrefix is obsolete. Use DeviceMetadata and GetDeviceName instead.
 
         [Fact]
         public void FunctionName_WithEnvironmentVariable_ReturnsValue()
@@ -197,77 +176,7 @@ namespace UnifiWebhookEventReceiverTests
             Assert.Equal("/tmp", result);
         }
 
-        [Fact]
-        public void ArchiveButtonX_WithEnvironmentVariable_ReturnsValue()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("ArchiveButtonX", "1500");
-
-            // Act
-            var result = AppConfiguration.ArchiveButtonX;
-
-            // Assert
-            Assert.Equal(1500, result);
-        }
-
-        [Fact]
-        public void ArchiveButtonX_WithInvalidEnvironmentVariable_ReturnsDefault()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("ArchiveButtonX", "invalid");
-
-            // Act
-            var result = AppConfiguration.ArchiveButtonX;
-
-            // Assert
-            Assert.Equal(1274, result); // Default value
-        }
-
-        [Fact]
-        public void ArchiveButtonX_WithoutEnvironmentVariable_ReturnsDefault()
-        {
-            // Act
-            var result = AppConfiguration.ArchiveButtonX;
-
-            // Assert
-            Assert.Equal(1274, result);
-        }
-
-        [Fact]
-        public void ArchiveButtonY_WithEnvironmentVariable_ReturnsValue()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("ArchiveButtonY", "300");
-
-            // Act
-            var result = AppConfiguration.ArchiveButtonY;
-
-            // Assert
-            Assert.Equal(300, result);
-        }
-
-        [Fact]
-        public void ArchiveButtonY_WithInvalidEnvironmentVariable_ReturnsDefault()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("ArchiveButtonY", "not-a-number");
-
-            // Act
-            var result = AppConfiguration.ArchiveButtonY;
-
-            // Assert
-            Assert.Equal(257, result); // Default value
-        }
-
-        [Fact]
-        public void ArchiveButtonY_WithoutEnvironmentVariable_ReturnsDefault()
-        {
-            // Act
-            var result = AppConfiguration.ArchiveButtonY;
-
-            // Assert
-            Assert.Equal(257, result);
-        }
+        // ArchiveButtonX/Y tests removed: Use GetDeviceCoordinates and DeviceMetadata for coordinate logic.
 
         [Fact]
         public void DownloadButtonX_WithEnvironmentVariable_ReturnsValue()

--- a/test/SimpleCoverageTests.cs
+++ b/test/SimpleCoverageTests.cs
@@ -108,22 +108,22 @@ namespace UnifiWebhookEventReceiver.Tests
             // Clear any environment variables that might affect the test
             var originalProcessingDelay = Environment.GetEnvironmentVariable("ProcessingDelaySeconds");
             Environment.SetEnvironmentVariable("ProcessingDelaySeconds", null);
-            
             try
             {
                 // Test that integer properties have reasonable default values
-                Assert.True(AppConfiguration.ArchiveButtonX > 0);
-                Assert.True(AppConfiguration.ArchiveButtonY > 0);
                 Assert.True(AppConfiguration.DownloadButtonX > 0);
                 Assert.True(AppConfiguration.DownloadButtonY > 0);
                 Assert.True(AppConfiguration.ProcessingDelaySeconds >= 0);
-                
-                // Test specific default values
-                Assert.Equal(1274, AppConfiguration.ArchiveButtonX);
-                Assert.Equal(257, AppConfiguration.ArchiveButtonY);
+
+                // Test specific default values for DownloadButton and ProcessingDelaySeconds
                 Assert.Equal(1095, AppConfiguration.DownloadButtonX);
                 Assert.Equal(275, AppConfiguration.DownloadButtonY);
                 Assert.Equal(120, AppConfiguration.ProcessingDelaySeconds);
+
+                // Test GetDeviceCoordinates default values (archive and download)
+                var coords = AppConfiguration.GetDeviceCoordinates("");
+                Assert.Equal((1205, 240), coords.archiveButton);
+                Assert.Equal((1026, 258), coords.downloadButton);
             }
             finally
             {


### PR DESCRIPTION
Removed legacy environment variable support for DevicePrefix, ArchiveButtonX, and ArchiveButtonY from AppConfiguration. Updated related tests to remove coverage for these obsolete members and migrated coordinate logic to use DeviceMetadata and GetDeviceCoordinates. Also cleaned up excessive logging in UnifiProtectService and fixed a typo in the readme for the DEVICE_METADATA variable.