### PR TITLE
Simplify Unifi domain handling in CloudFormation template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -912,20 +912,6 @@ The CloudFormation template automatically configures these Lambda environment va
 | `ArchiveButtonX` | CloudFormation parameter | X coordinate for archive button (default: 1274) |
 | `ArchiveButtonY` | CloudFormation parameter | Y coordinate for archive button (default: 257) |
 
-#### 📱 Pre-configured Device Mappings
-
-The template includes example device mappings:
-
-```yaml
-DeviceMac28704E113F64: "Backyard East"
-DeviceMacF4E2C67A2FE8: "Front"
-DeviceMac28704E113C44: "Side"
-DeviceMac28704E113F33: "Backyard West"
-DeviceMacF4E2C677E20F: "Door"
-```
-
-Update these in the CloudFormation template to match your Unifi device MAC addresses.
-
 ## 🧪 Testing
 
 ### 🔬 Unit Testing

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -151,22 +151,16 @@ Resources:
     Type: AWS::CertificateManager::Certificate
     Condition: UseUnifiDomain
     Properties:
-      DomainName: !Sub
-        - "${DevPrefix}${DomainName}"
-        - DevPrefix: !If [IsDevEnvironment, "dev-", ""]
-          DomainName: !If
+      DomainName: !If
+        - HasHttpsPrefix
+        - !Select [2, !Split ["/", !Ref UnifiHost]]
+        - !Ref UnifiHost
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !If
             - HasHttpsPrefix
             - !Select [2, !Split ["/", !Ref UnifiHost]]
             - !Ref UnifiHost
-      ValidationMethod: DNS
-      DomainValidationOptions:
-        - DomainName: !Sub
-            - "${DevPrefix}${DomainName}"
-            - DevPrefix: !If [IsDevEnvironment, "dev-", ""]
-              DomainName: !If
-                - HasHttpsPrefix
-                - !Select [2, !Split ["/", !Ref UnifiHost]]
-                - !Ref UnifiHost
           HostedZoneId: !Ref HostedZoneId
       CertificateExport: ENABLED
       Tags:
@@ -569,13 +563,10 @@ Resources:
     Condition: UseUnifiDomain
     Properties:
       HostedZoneId: !Ref HostedZoneId
-      Name: !Sub
-        - "${DevPrefix}${DomainName}"
-        - DevPrefix: !If [IsDevEnvironment, "dev-", ""]
-          DomainName: !If
-            - HasHttpsPrefix
-            - !Select [2, !Split ["/", !Ref UnifiHost]]
-            - !Ref UnifiHost
+      Name: !If
+        - HasHttpsPrefix
+        - !Select [2, !Split ["/", !Ref UnifiHost]]
+        - !Ref UnifiHost
       Type: A
       TTL: 300
       ResourceRecords:
@@ -761,13 +752,10 @@ Outputs:
   UnifiDomainName:
     Condition: UseUnifiDomain
     Description: UniFi domain name
-    Value: !Sub
-      - "${DevPrefix}${DomainName}"
-      - DevPrefix: !If [IsDevEnvironment, "dev-", ""]
-        DomainName: !If
-          - HasHttpsPrefix
-          - !Select [2, !Split ["/", !Ref UnifiHost]]
-          - !Ref UnifiHost
+    Value: !If
+      - HasHttpsPrefix
+      - !Select [2, !Split ["/", !Ref UnifiHost]]
+      - !Ref UnifiHost
   DNSRecordsCreated:
     Condition: UseCustomDomain
     Description: Confirmation that DNS records have been created


### PR DESCRIPTION
Refactored the CloudFormation template to remove the DevPrefix/DomainName substitution logic for Unifi domain resources and outputs, using conditional logic based on the presence of an HTTPS prefix instead. Also removed pre-configured device mapping examples from the readme for clarity.