### PR TITLE
Added Start of UI

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,85 @@
+name: Deploy UI CloudFormation Stack
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'feature-**'
+      - 'bugfix-**'
+      - 'hotfix-**'
+
+jobs:
+  deploy-ui:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      OIDC_ROLE_NAME: ${{ vars.OIDC_ROLE_NAME }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Print referenced environment variables
+        run: |
+          echo "AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}"
+          echo "OIDC_ROLE_NAME: ${{ vars.OIDC_ROLE_NAME }}"
+          echo "OwnerName: ${{ vars.OWNER_NAME }}"
+          echo "AppName: ${{ vars.APP_NAME_UI }}"
+          echo "AppDescription: ${{ vars.APP_DESCRIPTION }}"
+          echo "HostedZoneId: ${{ vars.HOSTED_ZONE_ID }}"
+          echo "SupportEmail: ${{ vars.SUPPORT_EMAIL }}"
+
+      - name: Determine environment and set UI domain
+        id: env
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "ENV_PREFIX=prod" >> $GITHUB_OUTPUT
+            echo "DOMAIN_NAME_UI=${{ vars.PROD_DOMAIN_NAME_UI }}" >> $GITHUB_OUTPUT
+          else
+            echo "ENV_PREFIX=dev" >> $GITHUB_OUTPUT
+            echo "DOMAIN_NAME_UI=${{ vars.DEV_DOMAIN_NAME_UI }}" >> $GITHUB_OUTPUT
+          fi
+          echo "Deploying UI to environment: $ENV_PREFIX"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.OIDC_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Deploy CloudFormation stack
+        run: |
+          aws cloudformation deploy \
+            --template-file templates/ui-cf-stack.yaml \
+            --stack-name bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }} \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --parameter-overrides \
+              OwnerName="${{ vars.OWNER_NAME }}" \
+              AppName="${{ vars.APP_NAME_UI }}" \
+              AppDescription="${{ vars.APP_DESCRIPTION }}" \
+              EnvPrefix="${{ steps.env.outputs.ENV_PREFIX }}" \
+              BucketName="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}" \
+              DomainName="${{ steps.env.outputs.DOMAIN_NAME_UI }}" \
+              HostedZoneId="${{ vars.HOSTED_ZONE_ID }}" \
+              SupportEmail="${{ vars.SUPPORT_EMAIL }}" \
+            --tags \
+              Owner="${{ vars.OWNER_NAME }}" \
+              AppName="${{ vars.APP_NAME_UI }}" \
+              Description="${{ vars.APP_DESCRIPTION }}" \
+              Environment="${{ steps.env.outputs.ENV_PREFIX }}"
+
+      - name: Copy UI contents to S3 bucket
+        run: |
+          BUCKET_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-event-backup-api-ui
+          aws s3 sync ui/ s3://$BUCKET_NAME/ --delete
+
+      - name: Invalidate CloudFront cache
+        run: |
+          DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
+            --stack-name bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-ui \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
+            --output text)
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -73,13 +73,13 @@ jobs:
 
       - name: Copy UI contents to S3 bucket
         run: |
-          BUCKET_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-event-backup-api-ui
+          BUCKET_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}
           aws s3 sync ui/ s3://$BUCKET_NAME/ --delete
 
       - name: Invalidate CloudFront cache
         run: |
           DISTRIBUTION_ID=$(aws cloudformation describe-stacks \
-            --stack-name bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-ui \
+            --stack-name bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }} \
             --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
             --output text)
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,4 +1,4 @@
-name: Deploy UI CloudFormation Stack
+name: Build, Test, and Deploy to AWS (UI)
 
 on:
   push:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    <h1>Hello World</h1>
+    <p>This is the starting static site for your Unifi Protect Event Backup API project.</p>
+</body>
+</html>

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -123,7 +123,7 @@ Conditions:
   HasUnifiHostIp: !Not [!Equals [!Ref UnifiHostIp, ""]]
   UseUnifiDomain: !And [!And [!Condition HasUnifiHost, !Condition HasUnifiHostIp], !Condition HasHostedZone]
   HasHttpsPrefix: !Not [!Equals [!Select [0, !Split ["://", !Ref UnifiHost]], !Ref UnifiHost]]
-  IsDevEnvironment: !Equals [!Ref EnvPrefix, "dev"]
+  IsProdEnvironment: !Equals [!Ref EnvPrefix, "prod"]
 
 # Resources
 Resources: 
@@ -162,7 +162,11 @@ Resources:
             - !Select [2, !Split ["/", !Ref UnifiHost]]
             - !Ref UnifiHost
           HostedZoneId: !Ref HostedZoneId
-      CertificateExport: ENABLED
+      CertificateExport:
+        Fn::If:
+          - IsProdEnvironment
+          - ENABLED
+          - DISABLED
       Tags:
         - Key: "Name"
           Value: !Sub "${FunctionName}-unifi-cert"

--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -1,0 +1,207 @@
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CloudFormation stack for static website hosting with S3 and CloudFront for the Unifi Protect Event Backup API UI.
+
+# Stack-level tags
+Metadata:
+  AWS::CloudFormation::Interface:
+    Tags:
+      - Key: Owner
+        Value: !Ref OwnerName
+      - Key: Description
+        Value: !Ref AppDescription
+      - Key: Environment
+        Value: !Ref EnvPrefix
+      - Key: AppName
+        Value: !Ref AppName
+      - Key: SupportEmail
+        Value: !Ref SupportEmail
+
+Parameters:
+  EnvPrefix:
+    Type: String
+    Description: Prefix for the environment (dev, prod, staging)
+    Default: dev
+  AppName:
+    Type: String
+    Description: Name of the application
+    Default: unifi-protect-event-backup
+  BucketName:
+    Type: String
+    Description: S3 bucket name for the static website
+    Default: !Sub "bf-${EnvPrefix}-${AppName}-ui"
+  DomainName:
+    Type: String
+    Description: Custom domain name for the static site (e.g., site.brentfoster.me)
+    Default: ""
+  HostedZoneId:
+    Type: String
+    Description: Route53 Hosted Zone ID for the domain
+    Default: ""
+
+Conditions:
+  HasCustomDomain: !Not [!Equals [!Ref DomainName, ""]]
+  HasHostedZone: !Not [!Equals [!Ref HostedZoneId, ""]]
+  UseCustomDomain: !And [!Condition HasCustomDomain, !Condition HasHostedZone]
+
+Resources:
+
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: UseCustomDomain
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Ref DomainName
+          HostedZoneId: !Ref HostedZoneId
+      Tags:
+        - Key: "Name"
+          Value: !Sub "bf-${EnvPrefix}-${AppName}-cert"
+
+  WebsiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      WebsiteConfiguration:
+        IndexDocument: index.html
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders:
+              - '*'
+            AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - '*'
+            Id: OpenCors
+            MaxAge: '3600'
+      Tags:
+        - Key: "Name"
+          Value: !Sub "bf-${EnvPrefix}-${AppName}-ui"
+
+  CloudFrontOriginIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Sub "bf-${EnvPrefix}-origin-identity"
+
+  WebUIPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref WebsiteBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              CanonicalUser: !GetAtt CloudFrontOriginIdentity.S3CanonicalUserId
+            Action: "s3:GetObject"
+            Resource: !Sub "${WebsiteBucket.Arn}/*"
+
+  WebsiteCloudFront:
+    Type: AWS::CloudFront::Distribution
+    DependsOn:
+      - WebsiteBucket
+    Properties:
+      DistributionConfig:
+        Origins:
+          - DomainName: !GetAtt WebsiteBucket.RegionalDomainName
+            Id: !Ref WebsiteBucket
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginIdentity}"
+            OriginCustomHeaders:
+              - HeaderName: Access-Control-Allow-Origin
+                HeaderValue: '*'
+        Enabled: true
+        Comment: !Sub "bf-${EnvPrefix} - ${AppName}"
+        Aliases: !If [UseCustomDomain, [!Ref DomainName], []]
+        DefaultRootObject: index.html
+        DefaultCacheBehavior:
+          TargetOriginId: !Ref WebsiteBucket
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods:
+            - HEAD
+            - DELETE
+            - POST
+            - GET
+            - OPTIONS
+            - PUT
+            - PATCH
+          CachedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          Compress: false
+          ForwardedValues:
+            QueryString: true
+            Cookies:
+              Forward: none
+            Headers:
+              - Access-Control-Request-Headers
+              - Access-Control-Request-Method
+              - Origin
+        PriceClass: PriceClass_100
+        Restrictions:
+          GeoRestriction:
+            RestrictionType: whitelist
+            Locations:
+              - US
+              - CA
+        ViewerCertificate: !If
+          - UseCustomDomain
+          - {
+              AcmCertificateArn: !Ref Certificate,
+              MinimumProtocolVersion: TLSv1.2_2021,
+              SslSupportMethod: sni-only
+            }
+          - { CloudFrontDefaultCertificate: true }
+        CustomErrorResponses:
+          - ErrorCode: 404
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+          - ErrorCode: 403
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+      Tags:
+        - Key: "Name"
+          Value: !Sub "bf-${EnvPrefix}-ui-cdn"
+
+  CloudFrontAliasRecordA:
+    Type: AWS::Route53::RecordSet
+    Condition: UseCustomDomain
+    Properties:
+      HostedZoneName: !Sub "${DomainName}."
+      Name: !Sub "${DomainName}."
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt WebsiteCloudFront.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+
+  CloudFrontAliasRecordAAAA:
+    Type: AWS::Route53::RecordSet
+    Condition: UseCustomDomain
+    Properties:
+      HostedZoneName: !Sub "${DomainName}."
+      Name: !Sub "${DomainName}."
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt WebsiteCloudFront.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+
+Outputs:
+  S3WebsiteURL:
+    Value: !GetAtt WebsiteBucket.WebsiteURL
+  CloudFrontDomain:
+    Value: !GetAtt WebsiteCloudFront.DomainName
+  CloudFrontDistributionId:
+    Description: "CloudFront Distribution ID"
+    Value: !Ref WebsiteCloudFront

--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -25,11 +25,11 @@ Parameters:
   AppName:
     Type: String
     Description: Name of the application
-    Default: unifi-protect-event-backup
+    Default: ""
   BucketName:
     Type: String
     Description: S3 bucket name for the static website
-    Default: !Sub "bf-${EnvPrefix}-${AppName}-ui"
+    Default: ""
   DomainName:
     Type: String
     Description: Custom domain name for the static site (e.g., site.brentfoster.me)

--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -179,8 +179,8 @@ Resources:
     Type: AWS::Route53::RecordSet
     Condition: UseCustomDomain
     Properties:
-      HostedZoneName: !Sub "${DomainName}."
-      Name: !Sub "${DomainName}."
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref DomainName
       Type: A
       AliasTarget:
         DNSName: !GetAtt WebsiteCloudFront.DomainName
@@ -190,8 +190,8 @@ Resources:
     Type: AWS::Route53::RecordSet
     Condition: UseCustomDomain
     Properties:
-      HostedZoneName: !Sub "${DomainName}."
-      Name: !Sub "${DomainName}."
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref DomainName
       Type: AAAA
       AliasTarget:
         DNSName: !GetAtt WebsiteCloudFront.DomainName

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    <h1>Hello World</h1>
+    <p>This is the starting static site for your Unifi Protect Event Backup API project.</p>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces infrastructure and deployment automation for a new static UI for the Unifi Protect Event Backup API project. It adds a CloudFormation template to provision AWS resources for static website hosting, a GitHub Actions workflow for automated deployment, and a starter static HTML page. Additionally, it corrects an environment condition and certificate export logic in an existing CloudFormation template.

**Infrastructure and Deployment Automation:**

* Added a new CloudFormation template (`templates/ui-cf-stack.yaml`) to provision AWS resources for static website hosting, including S3, CloudFront, ACM certificates, and Route53 records, with support for custom domains and environment-based configuration.
* Introduced a GitHub Actions workflow (`.github/workflows/deploy-ui.yml`) that builds, tests, and deploys the UI to AWS, handling environment detection, CloudFormation stack deployment, S3 uploads, and CloudFront cache invalidation.

**Static UI Initialization:**

* Added a starter static HTML page (`ui/index.html` and `frontend/index.html`) as the initial content for the UI.

**CloudFormation Logic Corrections:**

* In `templates/cf-stack-cs.yaml`, corrected the environment condition from `IsDevEnvironment` to `IsProdEnvironment` to properly distinguish production deployments.
* Updated the `CertificateExport` property to enable export only in production environments, improving certificate management logic.