### PR TITLE
Update workflow name to specify API deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 
-name: Build, Test, and Deploy to AWS
+name: Build, Test, and Deploy to AWS (API)
 
 # This workflow builds the application, runs unit tests, and deploys to AWS
 # Deployment will only proceed if all unit tests pass


### PR DESCRIPTION
Renamed the GitHub Actions workflow to 'Build, Test, and Deploy to AWS (API)' for clarity on the deployment target.