### PR TITLE
Move OpenAPI spec to docs/ and update references

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,81 +4,12 @@ info:
   description: |
     AWS Lambda function that receives and processes webhook events from Unifi Dream Machine Protect systems, 
     storing alarm event data and video files in S3 for backup and analysis.
-    
-    ## Features
-    - Real-time webhook processing from Unifi Protect systems
-    - Asynchronous video processing with SQS delay queues
-    - Secure S3 storage with date-organized folder structure
-    - Device MAC address to human-readable name mapping
-    - RESTful event retrieval API
-    - Direct video file download with optimized search
-    - Comprehensive CORS support for web clients
-    
-    ## Architecture
-    This serverless application uses AWS Lambda, API Gateway, SQS, and S3 to provide a scalable, 
-    cost-effective solution for backing up Unifi Protect alarm events and video files. 
-    
-    ### Event Processing Flow:
-    1. **Webhook Receipt**: API Gateway receives Unifi Protect webhook
-    2. **Immediate Response**: Lambda returns 200 OK and queues event for processing
-    3. **Delayed Processing**: SQS delivers message after 2-minute delay
-    4. **Video Download**: Lambda processes event and downloads video from Unifi Protect
-    5. **Storage**: Event data and video files stored in S3 with date organization
-    
-    The delay ensures video files are fully available in Unifi Protect before download attempts,
-    significantly improving reliability and reducing failed downloads.
-    
-    ## Video Download Optimization
-    The latest video endpoint uses an efficient search algorithm that leverages the date-organized
-    folder structure in S3. Instead of scanning all objects, it starts from today's date folder
-    and works backwards day by day until a video is found, making retrieval fast and cost-effective.
-    
-    ## Authentication
-    All endpoints require an API key passed in the `X-API-Key` header. The API key is generated 
-    during CloudFormation deployment and can be retrieved from the AWS API Gateway console.
-    
-    ## Rate Limiting
-    API Gateway enforces rate limiting and throttling to prevent abuse. Default limits are:
-    - Burst: 5000 requests
-    - Rate: 10000 requests per second
-    
-    ## Data Retention
-    Events are stored indefinitely in S3. Configure S3 lifecycle policies for automatic archival 
-    or deletion based on your retention requirements.
-  version: 1.0.0
-  contact:
-    name: Brent Foster
-    email: brent@brentfoster.me
-    url: https://github.com/engineerthefuture/unifi-protect-event-backup-api
-  license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
-  termsOfService: https://github.com/engineerthefuture/unifi-protect-event-backup-api/blob/main/LICENSE
-
-servers:
-  - url: https://your-api-id.execute-api.us-east-1.amazonaws.com/prod
-    description: Production AWS API Gateway endpoint
-  - url: https://your-api-id.execute-api.us-west-2.amazonaws.com/prod
-    description: Production AWS API Gateway endpoint (US West)
-  - url: https://staging-api-id.execute-api.us-east-1.amazonaws.com/staging
-    description: Staging environment (optional)
-
-security:
-  - ApiKeyAuth: []
-
-paths:
-  /alarmevent:
-    post:
-      summary: Process Unifi Protect alarm webhook
-      description: |
-        Receives webhook events from Unifi Dream Machine Protect systems and queues them for delayed processing.
-        
-        **Processing Steps:**
-        1. Validates incoming JSON payload structure
-        2. Extracts alarm triggers and device information
-        3. Queues event for processing with configurable delay (default: 2 minutes)
-        4. Returns immediate success response with queue information
-        
+    # This file has moved.
+    #
+    # The OpenAPI specification is now located at:
+    #   docs/openapi.yaml
+    #
+    # Please update any references to use the new location.
         **Delayed Processing Benefits:**
         - Ensures video files are fully available before download attempts
         - Improves reliability and reduces failed downloads

--- a/readme.md
+++ b/readme.md
@@ -514,10 +514,10 @@ Fetches and stores current camera metadata from the Unifi Protect API
 
 
 **Complete API Documentation:**
-- [openapi.yaml](openapi.yaml) (OpenAPI 3.0 spec)
+- [docs/openapi.yaml](docs/openapi.yaml) (OpenAPI 3.0 spec)
 - [Swagger UI (OpenAPI) – GitHub Pages](https://engineerthefuture.github.io/unifi-protect-event-backup-api/index.html)
 
-The full OpenAPI 3.0 specification is available in the [`openapi.yaml`](openapi.yaml) file and includes:
+The full OpenAPI 3.0 specification is available in the [`docs/openapi.yaml`](docs/openapi.yaml) file and includes:
 
 - 📝 **Complete endpoint documentation** with detailed request/response schemas
 - 🎯 **Interactive examples** for all supported event types (motion, person, vehicle detection)
@@ -531,39 +531,39 @@ The full OpenAPI 3.0 specification is available in the [`openapi.yaml`](openapi.
 #### **1. View Interactive Documentation**
 ```bash
 # Swagger UI
-npx swagger-ui-serve openapi.yaml
+npx swagger-ui-serve docs/openapi.yaml
 
 # Redoc
-npx redoc-cli serve openapi.yaml
+npx redoc-cli serve docs/openapi.yaml
 ```
 
 #### **2. Generate Client SDKs**
 ```bash
 # TypeScript/JavaScript client
 npx @openapitools/openapi-generator-cli generate \
-  -i openapi.yaml \
+  -i docs/openapi.yaml \
   -g typescript-axios \
   -o ./generated-client
 
 # Python client
 openapi-generator-cli generate \
-  -i openapi.yaml \
+  -i docs/openapi.yaml \
   -g python \
   -o ./python-client
 ```
 
 #### **3. API Testing**
-- Import `openapi.yaml` into **Postman**, **Insomnia**, or **Bruno**
+- Import `docs/openapi.yaml` into **Postman**, **Insomnia**, or **Bruno**
 - Use with **curl** for command-line testing
-- Create mock servers with **Prism**: `npx @stoplight/prism mock openapi.yaml`
+- Create mock servers with **Prism**: `npx @stoplight/prism mock docs/openapi.yaml`
 
 #### **4. Validation**
 ```bash
 # Validate specification
-npx swagger-parser validate openapi.yaml
+npx swagger-parser validate docs/openapi.yaml
 
 # Lint for best practices
-npx spectral lint openapi.yaml
+npx spectral lint docs/openapi.yaml
 ```
 
 ### 📋 Quick Reference
@@ -1303,7 +1303,7 @@ aws sqs send-message \
 ## 📚 Documentation
 
 - 🚀 **[Quickstart Guide](docs/QUICKSTART.md)** - Step-by-step setup for new AWS accounts
-- 📖 **[API Documentation](openapi.yaml)** - Complete OpenAPI 3.0 specification
+- 📖 **[API Documentation](docs/openapi.yaml)** - Complete OpenAPI 3.0 specification
 - 🚀 **[Deployment Guide](docs/DEPLOYMENT.md)** - Multi-environment deployment instructions
 
 ## 📄 License

--- a/ui/openapi.yaml
+++ b/ui/openapi.yaml
@@ -1,0 +1,1131 @@
+openapi: 3.0.3
+info:
+  title: Unifi Protect Event Backup API
+  description: |
+    AWS Lambda function that receives and processes webhook events from Unifi Dream Machine Protect systems, 
+    storing alarm event data and video files in S3 for backup and analysis.
+    # This file has moved.
+    #
+    # The OpenAPI specification is now located at:
+    #   docs/openapi.yaml
+    #
+    # Please update any references to use the new location.
+        **Delayed Processing Benefits:**
+        - Ensures video files are fully available before download attempts
+        - Improves reliability and reduces failed downloads
+        - Provides immediate webhook response for better system performance
+        
+        **Asynchronous Processing:**
+        After the delay period, the system:
+        1. Maps device MAC addresses to human-readable names
+        2. Downloads video files from Unifi Protect
+        3. Stores enriched event data and videos in S3 with date-based organization
+        
+        **Storage Format:**
+        Events are stored as JSON files in S3 with the path structure:
+        `{bucket}/{YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.json`
+        
+        **Error Handling:**
+        - Malformed JSON returns 400 Bad Request
+        - Missing required fields return 400 Bad Request
+        - SQS configuration errors return 500 Internal Server Error
+        - All errors include descriptive error messages
+      operationId: processAlarmEvent
+      tags:
+        - Alarm Events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnifiWebhookRequest'
+            examples:
+              motionDetection:
+                summary: Motion Detection Event
+                description: Typical motion detection event from outdoor camera
+                value:
+                  alarm:
+                    name: "Backup Alarm Event"
+                    sources:
+                      - device: "28704E113F64"
+                        type: "include"
+                    conditions:
+                      - condition:
+                          type: "is"
+                          source: "motion"
+                    triggers:
+                      - key: "motion"
+                        device: "28704E113F33"
+                        eventId: "67b389ab005ec703e40075a5"
+                        zones:
+                          zone: []
+                          line: []
+                          loiter: []
+                  timestamp: 1739819436108
+              personDetection:
+                summary: Person Detection Event
+                description: AI-powered person detection with zone information
+                value:
+                  alarm:
+                    name: "Person Detection Alarm"
+                    sources:
+                      - device: "F4E2C67A2FE8"
+                        type: "include"
+                    conditions:
+                      - condition:
+                          type: "is"
+                          source: "person"
+                    triggers:
+                      - key: "person"
+                        device: "F4E2C67A2FE8"
+                        eventId: "67b389ab005ec703e40075a6"
+                        zones:
+                          zone: ["entrance", "driveway"]
+                          line: []
+                          loiter: []
+                  timestamp: 1739819500000
+              vehicleDetection:
+                summary: Vehicle Detection Event
+                description: Vehicle detection with multiple zones triggered
+                value:
+                  alarm:
+                    name: "Vehicle Detection Alarm"
+                    sources:
+                      - device: "28704E113C44"
+                        type: "include"
+                    conditions:
+                      - condition:
+                          type: "is"
+                          source: "vehicle"
+                    triggers:
+                      - key: "vehicle"
+                        device: "28704E113C44"
+                        eventId: "67b389ab005ec703e40075a7"
+                        zones:
+                          zone: ["street", "driveway"]
+                          line: ["property_line"]
+                          loiter: []
+                  timestamp: 1739819600000
+      responses:
+        '200':
+          description: Event successfully queued for processing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueuedEventResponse'
+              examples:
+                motionQueued:
+                  summary: Motion event queued
+                  value:
+                    msg: "Alarm event has been queued for processing"
+                    eventId: "67b389ab005ec703e40075a5"
+                    device: "28704E113F33"
+                    processingDelay: 120
+                    messageId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    estimatedProcessingTime: "2025-01-17T20:47:56 UTC"
+                personQueued:
+                  summary: Person detection queued
+                  value:
+                    msg: "Alarm event has been queued for processing"
+                    eventId: "67b389ab005ec703e40075a7"
+                    device: "F4E2C67A2FE8"
+                    processingDelay: 120
+                    messageId: "b2c3d4e5-f6g7-8901-bcde-f23456789012"
+                    estimatedProcessingTime: "2025-01-17T20:47:00 UTC"
+        '400':
+          description: Bad request - Invalid or malformed data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidJson:
+                  summary: Invalid JSON format
+                  value:
+                    msg: "ERROR 400: malformed or invalid request format"
+                missingAlarm:
+                  summary: Missing alarm object
+                  value:
+                    msg: "ERROR 400: No alarm object found in request"
+                noTriggers:
+                  summary: Missing triggers
+                  value:
+                    msg: "ERROR 400: you must have triggers in your payload"
+                invalidTimestamp:
+                  summary: Invalid timestamp
+                  value:
+                    msg: "ERROR 400: timestamp must be a valid Unix timestamp in milliseconds"
+        '401':
+          description: Unauthorized - Invalid or missing API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingKey:
+                  summary: Missing API key
+                  value:
+                    message: "Unauthorized"
+                invalidKey:
+                  summary: Invalid API key
+                  value:
+                    message: "Forbidden"
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                msg: "Rate limit exceeded. Please reduce request frequency."
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                configError:
+                  summary: Configuration error
+                  value:
+                    msg: "Server configuration error: StorageBucket not configured"
+                s3Error:
+                  summary: Storage error
+                  value:
+                    msg: "Failed to store event in S3: Access denied"
+    
+    options:
+      summary: CORS preflight request
+      description: |
+        Handles CORS preflight requests for web client support.
+        
+        **CORS Configuration:**
+        - **Allow-Origin**: `*` (configurable for production)
+        - **Allow-Methods**: `OPTIONS, POST, GET`
+        - **Allow-Headers**: `Content-Type, X-API-Key`
+        - **Max-Age**: 86400 seconds (24 hours)
+        
+        **Usage:**
+        Web browsers automatically send OPTIONS requests before cross-origin POST/GET requests.
+        This endpoint ensures proper CORS headers are returned to allow web applications to
+        interact with the API from different domains.
+      operationId: handleCorsOptions
+      tags:
+        - CORS
+      responses:
+        '200':
+          description: CORS headers provided
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                example: "*"
+              description: Allowed origins for cross-origin requests
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+                example: "OPTIONS,POST,GET"
+              description: Allowed HTTP methods
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+                example: "Content-Type,X-API-Key"
+              description: Allowed request headers
+            Access-Control-Max-Age:
+              schema:
+                type: integer
+                example: 86400
+              description: Preflight cache duration in seconds
+
+  /:
+    get:
+      summary: Download video by event ID
+      description: |
+        Downloads a video file by searching for the specified Unifi Protect event ID and returning a presigned URL for direct download.
+        
+        **How it works:**
+        1. Searches through date-organized S3 folders (YYYY-MM-DD) for JSON event files
+        2. Parses each event file to find the matching eventId in trigger data
+        3. Locates the corresponding video file (.mp4)
+        4. Generates a secure, time-limited presigned URL for direct S3 download
+        5. Returns complete event context and metadata along with download URL
+        
+        **Event ID Source:**
+        Event IDs are Unifi Protect's internal identifiers found in the `trigger.eventId` field of stored alarm events.
+        These are typically 24-character hexadecimal strings (e.g., `67b389ab005ec703e40075a5`).
+        
+        **Why Presigned URL?**
+        Video files typically exceed API Gateway's 6MB payload limit, so this endpoint returns a secure, 
+        time-limited URL that allows direct download from S3. This approach is more efficient and can handle videos of any size.
+        
+        **Search Efficiency:**
+        Uses backwards chronological search starting from today, examining up to 90 days of date folders.
+        The search stops as soon as the matching event is found, making it efficient even with large datasets.
+        
+        **Response Data:**
+        Returns comprehensive information including download URL, event metadata, device details, 
+        trigger information, and complete alarm context from the original event.
+      operationId: getVideoByEventId
+      tags:
+        - Video Retrieval
+      parameters:
+        - name: eventId
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-fA-F0-9]{24}$'
+            minLength: 24
+            maxLength: 24
+          description: |
+            Unifi Protect event identifier for video download.
+            
+            **Format Requirements:**
+            - **Length**: Exactly 24 hexadecimal characters
+            - **Source**: Found in the trigger.eventId field of stored alarm events
+            - **Purpose**: Used to locate and download the corresponding video file
+            
+            **Examples:**
+            - `67b389ab005ec703e40075a5` (Motion detection video)
+            - `67b389ab005ec703e40075a6` (Person detection video)
+            
+            **How to obtain:**
+            Event IDs are included in webhook payloads from Unifi Protect and stored in the alarm event JSON files.
+          examples:
+            motionVideo:
+              summary: Motion detection video
+              value: "67b389ab005ec703e40075a5"
+            personVideo:
+              summary: Person detection video
+              value: "67b389ab005ec703e40075a6"
+      responses:
+        '200':
+          description: Video download URL successfully generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoDownloadResponse'
+              examples:
+                motionVideoResponse:
+                  summary: Motion detection video download
+                  value:
+                    downloadUrl: "https://s3.amazonaws.com/bucket/2025-01-17/28704E113F33_1739819436108.mp4?X-Amz-Signature=..."
+                    filename: "event_67b389ab005ec703e40075a5_2025-01-17_20-43-56.mp4"
+                    videoKey: "2025-01-17/28704E113F33_1739819436108.mp4"
+                    eventKey: "2025-01-17/28704E113F33_1739819436108.json"
+                    eventId: "67b389ab005ec703e40075a5"
+                    timestamp: 1739819436108
+                    eventDate: "2025-01-17 20:43:56"
+                    expiresAt: "2025-01-17 21:43:56 UTC"
+                    eventData:
+                      name: "Motion Detection Alert"
+                      timestamp: 1739819436108
+                      triggers:
+                        - key: "motion"
+                          device: "28704E113F33"
+                          eventId: "67b389ab005ec703e40075a5"
+                          deviceName: "Backyard West"
+                          zones:
+                            zone: []
+                            line: []
+                            loiter: []
+                    message: "Use the downloadUrl to download the video file directly. URL expires in 1 hour."
+                personVideoResponse:
+                  summary: Person detection video download
+                  value:
+                    downloadUrl: "https://s3.amazonaws.com/bucket/2025-01-17/F4E2C67A2FE8_1739819500000.mp4?X-Amz-Signature=..."
+                    filename: "event_67b389ab005ec703e40075a6_2025-01-17_20-45-00.mp4"
+                    videoKey: "2025-01-17/F4E2C67A2FE8_1739819500000.mp4"
+                    eventKey: "2025-01-17/F4E2C67A2FE8_1739819500000.json"
+                    eventId: "67b389ab005ec703e40075a6"
+                    timestamp: 1739819500000
+                    eventDate: "2025-01-17 20:45:00"
+                    expiresAt: "2025-01-17 21:45:00 UTC"
+                    eventData:
+                      name: "Person Detection Alert"
+                      timestamp: 1739819500000
+                      triggers:
+                        - key: "person"
+                          device: "F4E2C67A2FE8"
+                          eventId: "67b389ab005ec703e40075a6"
+                          deviceName: "Front Camera"
+                          zones:
+                            zone: ["entrance", "driveway"]
+                            line: []
+                            loiter: []
+                    message: "Use the downloadUrl to download the video file directly. URL expires in 1 hour."
+        '400':
+          description: Bad request - Missing or invalid eventId parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingEventId:
+                  summary: Missing eventId parameter
+                  value:
+                    msg: "Missing required parameter. Provide 'eventId' for video download."
+                invalidEventId:
+                  summary: Invalid event ID format
+                  value:
+                    msg: "EventId parameter is required"
+                malformedEventId:
+                  summary: Malformed event ID
+                  value:
+                    msg: "ERROR 400: eventId must be a 24-character hexadecimal string"
+        '404':
+          description: Event or video not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                eventNotFound:
+                  summary: Event with specified eventId not found
+                  value:
+                    msg: "Event with eventId 67b389ab005ec703e40075a5 not found"
+                videoFileNotFound:
+                  summary: Event found but video file missing
+                  value:
+                    msg: "Video file for event 67b389ab005ec703e40075a5 not found"
+                searchTimeout:
+                  summary: Event not found within search timeframe
+                  value:
+                    msg: "Event with eventId 67b389ab005ec703e40075a5 not found"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                s3Error:
+                  summary: S3 access error
+                  value:
+                    msg: "Failed to retrieve event from S3: Access denied"
+                configError:
+                  summary: Configuration error
+                  value:
+                    msg: "Server configuration error: StorageBucket not configured"
+
+  /latestvideo:
+    get:
+      summary: Get latest video download URL
+      description: |
+        Finds the most recent video file (.mp4) from stored alarm events and returns a presigned URL for download.
+        
+        **Why Presigned URL?**
+        Video files typically exceed API Gateway's 6MB payload limit, so instead of returning the video data directly,
+        this endpoint returns a secure, time-limited URL that allows direct download from S3. This approach is more
+        efficient and can handle videos of any size.
+        
+        **Search Algorithm:**
+        This endpoint uses an optimized search that efficiently searches through date-organized 
+        folders in S3 to find the most recent video file. It starts from today's date folder 
+        and works backwards day by day until a video is found, making it much more efficient 
+        than scanning all objects in the bucket.
+        
+        **Search Process:**
+        1. Start from today's date folder (YYYY-MM-DD format)
+        2. Search for .mp4 files in that folder
+        3. If found, return metadata for the one with the highest timestamp
+        4. If not found, move to previous day and repeat
+        5. Continue for up to 30 days maximum
+        
+        **File Format:**
+        Video files follow the naming pattern: `{eventId}_{deviceMac}_{timestamp}.mp4`
+        - **deviceMac**: 12-character hexadecimal MAC address
+        - **timestamp**: Unix timestamp in milliseconds when the event occurred
+        
+        **Storage Organization:**
+        Videos are stored in S3 with date-based organization:
+        `s3://{bucket}/{YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.mp4`
+        
+        **Response Format:**
+        Returns JSON containing:
+        - **downloadUrl**: Presigned S3 URL for direct download (expires in 1 hour)
+        - **filename**: Suggested filename for download
+        - **metadata**: Event timestamp, date, and video key information
+        - **eventData**: Complete alarm event details including device name, trigger type, zones, and timestamps
+        
+        **Security:**
+        - Presigned URLs expire after 1 hour for security
+        - URLs include proper Content-Disposition headers for filename handling
+        - Direct S3 access without requiring API credentials
+        
+        **Use Cases:**
+        - Quick access to most recent security footage
+        - Automated monitoring systems that can handle URLs
+        - Mobile applications for security alerts
+        - Integration with notification systems
+      operationId: getLatestVideo
+      tags:
+        - Video Retrieval
+      responses:
+        '200':
+          description: Latest video metadata and download URL successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - downloadUrl
+                  - filename
+                  - videoKey
+                  - eventKey
+                  - timestamp
+                  - eventDate
+                  - expiresAt
+                  - message
+                properties:
+                  downloadUrl:
+                    type: string
+                    format: uri
+                    description: |
+                      Presigned S3 URL for direct video download. This URL expires after 1 hour for security.
+                      The URL includes proper headers to suggest the filename when downloaded.
+                    example: "https://s3.amazonaws.com/bucket/2025-01-17/28704E113F33_1739819436108.mp4?AWSAccessKeyId=...&Expires=...&Signature=..."
+                  filename:
+                    type: string
+                    description: |
+                      Suggested filename for the video download based on the event timestamp.
+                      Format: latest_video_{YYYY-MM-DD_HH-mm-ss}.mp4
+                    example: "latest_video_2025-01-17_20-43-56.mp4"
+                  videoKey:
+                    type: string
+                    description: |
+                      S3 object key for the video file, useful for logging and tracking.
+                      Format: {YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.mp4
+                    example: "2025-01-17/28704E113F33_1739819436108.mp4"
+                  eventKey:
+                    type: string
+                    description: |
+                      S3 object key for the corresponding event JSON data.
+                      Format: {YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.json
+                    example: "2025-01-17/28704E113F33_1739819436108.json"
+                  timestamp:
+                    type: integer
+                    format: int64
+                    description: |
+                      Unix timestamp in milliseconds when the alarm event occurred.
+                    example: 1739819436108
+                  eventDate:
+                    type: string
+                    description: |
+                      Human-readable date and time when the event occurred.
+                      Format: YYYY-MM-DD HH:mm:ss
+                    example: "2025-01-17 20:43:56"
+                  expiresAt:
+                    type: string
+                    description: |
+                      When the download URL expires in UTC.
+                      Format: YYYY-MM-DD HH:mm:ss UTC
+                    example: "2025-01-17 21:43:56 UTC"
+                  eventData:
+                    type: object
+                    nullable: true
+                    description: |
+                      Complete alarm event details from the corresponding JSON file, including device name,
+                      trigger type, zones, timestamps, and other event metadata. May be null if the
+                      corresponding event file is not found.
+                    properties:
+                      name:
+                        type: string
+                        description: "Name of the alarm configuration"
+                        example: "Motion Detection Alert"
+                      timestamp:
+                        type: integer
+                        format: int64
+                        description: "Unix timestamp when the event occurred"
+                        example: 1739819436108
+                      triggers:
+                        type: array
+                        description: "List of trigger events that activated this alarm"
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: "Type of detection (motion, person, vehicle, etc.)"
+                              example: "motion"
+                            device:
+                              type: string
+                              description: "MAC address of the device that detected the event"
+                              example: "28704E113F33"
+                            deviceName:
+                              type: string
+                              description: "Human-readable device name"
+                              example: "Backyard West"
+                            eventId:
+                              type: string
+                              description: "Unique event identifier in Unifi Protect"
+                              example: "67b389ab005ec703e40075a5"
+                            date:
+                              type: string
+                              description: "ISO formatted event timestamp"
+                              example: "2025-01-17T20:43:56"
+                            zones:
+                              type: object
+                              description: "Detection zones that were triggered"
+                              properties:
+                                zone:
+                                  type: array
+                                  items:
+                                    type: string
+                                  example: ["entrance", "driveway"]
+                                line:
+                                  type: array
+                                  items:
+                                    type: string
+                                  example: ["property_line"]
+                                loiter:
+                                  type: array
+                                  items:
+                                    type: string
+                                  example: []
+                  message:
+                    type: string
+                    description: |
+                      Instructions for using the download URL.
+                    example: "Use the downloadUrl to download the video file directly. URL expires in 1 hour."
+              examples:
+                motionVideo:
+                  summary: Motion detection video URL with event data
+                  description: "Download URL and complete event details for motion detection event from Backyard West camera"
+                  value:
+                    downloadUrl: "https://s3.amazonaws.com/unifi-events/2025-01-17/28704E113F33_1739819436108.mp4?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1739823036&Signature=example..."
+                    filename: "latest_video_2025-01-17_20-43-56.mp4"
+                    videoKey: "2025-01-17/28704E113F33_1739819436108.mp4"
+                    eventKey: "2025-01-17/28704E113F33_1739819436108.json"
+                    timestamp: 1739819436108
+                    eventDate: "2025-01-17 20:43:56"
+                    expiresAt: "2025-01-17 21:43:56 UTC"
+                    eventData:
+                      name: "Motion Detection Alert"
+                      timestamp: 1739819436108
+                      triggers:
+                        - key: "motion"
+                          device: "28704E113F33"
+                          deviceName: "Backyard West"
+                          eventId: "67b389ab005ec703e40075a5"
+                          date: "2025-01-17T20:43:56"
+                          zones:
+                            zone: []
+                            line: []
+                            loiter: []
+                      sources:
+                        - device: "28704E113F64"
+                          type: "include"
+                      conditions:
+                        - condition:
+                            type: "is"
+                            source: "motion"
+                      eventPath: "/protect/events/67b389ab005ec703e40075a5"
+                      eventLocalLink: "https://udm.local/protect/events/67b389ab005ec703e40075a5"
+                    message: "Use the downloadUrl to download the video file directly. URL expires in 1 hour."
+        '404':
+          description: No video files found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                noVideos:
+                  summary: No videos in storage
+                  value:
+                    msg: "No video files found"
+                searchTimeout:
+                  summary: No videos found within search window
+                  value:
+                    msg: "No video files found in the last 30 days"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                s3Error:
+                  summary: S3 access error
+                  value:
+                    msg: "Error retrieving latest video: Access denied"
+                configError:
+                  summary: Configuration error
+                  value:
+                    msg: "Server configuration error: StorageBucket not configured"
+                searchError:
+                  summary: Search algorithm error
+                  value:
+                    msg: "Error retrieving latest video: Failed to search date folders"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        API key required for all requests. 
+        
+        **Obtaining API Key:**
+        1. Deploy the CloudFormation stack
+        2. Retrieve from AWS API Gateway console
+        3. Or use AWS CLI: `aws apigateway get-api-keys --include-values`
+        
+        **Usage:**
+        Include in all requests as a header:
+        ```
+        X-API-Key: your-api-key-here
+        ```
+        
+        **Security Notes:**
+        - Keep API keys secure and rotate regularly
+        - Use different keys for different environments
+        - Monitor API key usage in CloudWatch
+
+  schemas:
+    UnifiWebhookRequest:
+      type: object
+      required:
+        - alarm
+        - timestamp
+      properties:
+        alarm:
+          $ref: '#/components/schemas/AlarmObject'
+        timestamp:
+          type: integer
+          format: int64
+          minimum: 1000000000000
+          maximum: 9999999999999
+          description: |
+            Unix timestamp in milliseconds when the event occurred.
+            Must be between 1000000000000 (2001-09-09) and 9999999999999 (2286-11-20).
+          example: 1739819436108
+      description: |
+        Webhook request payload sent by Unifi Dream Machine Protect systems when alarm events occur.
+        
+        **Source:** Unifi Protect webhook configuration
+        **Content-Type:** application/json
+        **Frequency:** Real-time (as events occur)
+
+    AlarmObject:
+      type: object
+      required:
+        - name
+        - triggers
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          description: |
+            Human-readable name of the alarm configuration as defined in Unifi Protect.
+            This corresponds to the alarm rule name in the Unifi Protect web interface.
+          example: "Backup Alarm Event"
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlarmSource'
+          description: |
+            List of devices included or excluded in the alarm configuration.
+            Defines which cameras and devices are monitored by this alarm rule.
+          minItems: 0
+          maxItems: 50
+        conditions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlarmCondition'
+          description: |
+            Conditions that must be met to trigger the alarm.
+            These define the types of detection events that activate the alarm.
+          minItems: 0
+          maxItems: 20
+        triggers:
+          type: array
+          minItems: 1
+          maxItems: 10
+          items:
+            $ref: '#/components/schemas/AlarmTrigger'
+          description: |
+            List of trigger events that activated this alarm.
+            At least one trigger is required for a valid alarm event.
+        eventPath:
+          type: string
+          description: |
+            Internal path to the event in Unifi Protect system.
+            Used for linking back to the original event in the Unifi interface.
+          example: "/protect/events/67b389ab005ec703e40075a5"
+        eventLocalLink:
+          type: string
+          format: uri
+          description: |
+            Local URL to view the event in Unifi Protect web interface.
+            Only accessible from networks that can reach the UDM.
+          example: "https://udm.local/protect/events/67b389ab005ec703e40075a5"
+
+    AlarmSource:
+      type: object
+      required:
+        - device
+        - type
+      properties:
+        device:
+          type: string
+          pattern: '^[A-Fa-f0-9]{12}$'
+          description: |
+            Device MAC address in 12-character hexadecimal format (no separators).
+            This uniquely identifies the Unifi Protect camera or device.
+            
+            **Format:** AABBCCDDEEFF (no colons, dashes, or spaces)
+          example: "28704E113F64"
+        type:
+          type: string
+          enum: ["include", "exclude"]
+          description: |
+            Whether this device is included or excluded from the alarm rule.
+            
+            - **include**: Device events will trigger the alarm
+            - **exclude**: Device events will not trigger the alarm
+          example: "include"
+
+    AlarmCondition:
+      type: object
+      required:
+        - condition
+      properties:
+        condition:
+          type: object
+          required:
+            - type
+            - source
+          properties:
+            type:
+              type: string
+              enum: ["is", "is_not"]
+              description: |
+                Type of condition evaluation.
+                
+                - **is**: Alarm triggers when the source event occurs
+                - **is_not**: Alarm triggers when the source event does NOT occur
+              example: "is"
+            source:
+              type: string
+              enum: ["motion", "person", "vehicle", "package", "intrusion", "object"]
+              description: |
+                Type of detection that the condition evaluates.
+                
+                - **motion**: General motion detection
+                - **person**: AI-powered person detection
+                - **vehicle**: AI-powered vehicle detection
+                - **package**: AI-powered package detection
+                - **intrusion**: Zone intrusion detection
+                - **object**: General object detection
+              example: "motion"
+
+    AlarmTrigger:
+      type: object
+      required:
+        - key
+        - device
+        - eventId
+      properties:
+        key:
+          type: string
+          enum: ["motion", "person", "vehicle", "package", "intrusion", "object"]
+          description: |
+            Type of detection that triggered the alarm.
+            Must match one of the condition sources in the alarm configuration.
+          example: "motion"
+        device:
+          type: string
+          pattern: '^[A-Fa-f0-9]{12}$'
+          description: |
+            MAC address of the device that detected the event.
+            Format: 12 hexadecimal characters without separators.
+          example: "28704E113F33"
+        eventId:
+          type: string
+          minLength: 1
+          maxLength: 50
+          description: |
+            Unique identifier for this specific detection event in Unifi Protect.
+            Used to link back to video footage and event details.
+          example: "67b389ab005ec703e40075a5"
+        zones:
+          type: object
+          properties:
+            zone:
+              type: array
+              items:
+                type: string
+              description: |
+                Named detection zones within the camera's field of view that were triggered.
+                These correspond to zones configured in Unifi Protect.
+              example: ["entrance", "driveway"]
+            line:
+              type: array
+              items:
+                type: string
+              description: |
+                Line crossing detection zones that were triggered.
+                Used for tracking movement across defined boundaries.
+              example: ["property_line"]
+            loiter:
+              type: array
+              items:
+                type: string
+              description: |
+                Loitering detection zones that were triggered.
+                Used for detecting prolonged presence in specific areas.
+              example: []
+          description: |
+            Specific zones within the camera's field of view that triggered the detection.
+            Zones are configured in the Unifi Protect web interface.
+        deviceName:
+          type: string
+          description: |
+            Human-readable device name (added during processing).
+            Mapped from MAC address using environment variables.
+          example: "Backyard West"
+          readOnly: true
+        date:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 formatted timestamp (added during processing).
+            Converted from the Unix timestamp for readability.
+          example: "2025-01-17T20:43:56"
+          readOnly: true
+        eventKey:
+          type: string
+          description: |
+            Unique key for retrieving this event (added during processing).
+            Format: {eventId}_{deviceMac}_{timestamp}.json
+          example: "28704E113F33_1739819436108.json"
+          readOnly: true
+
+    StoredAlarmEvent:
+      allOf:
+        - $ref: '#/components/schemas/AlarmObject'
+        - type: object
+          properties:
+            timestamp:
+              type: integer
+              format: int64
+              description: |
+                Unix timestamp in milliseconds when the event occurred.
+                Original timestamp from the webhook request.
+              example: 1739819436108
+      description: |
+        Alarm event as stored in S3 with additional processing metadata.
+        
+        **Storage Location:** `s3://{bucket}/{YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.json`
+        **Retention:** Indefinite (configure S3 lifecycle policies as needed)
+        **Encryption:** Server-side encryption with AES-256
+
+    SuccessResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: |
+            Detailed success message with event processing information.
+            Includes event key, device name, and formatted timestamp for reference.
+          example: "bf-prod-lambda-unifi-protect-event-backup-api has successfully processed the Unifi alarm event webhook with key 28704E113F33_1739819436108.json for Backyard West that occurred at 2025-01-17T20:43:56."
+
+    QueuedEventResponse:
+      type: object
+      required:
+        - msg
+        - eventId
+        - device
+        - processingDelay
+        - messageId
+        - estimatedProcessingTime
+      properties:
+        msg:
+          type: string
+          description: Confirmation message that the event has been queued
+          example: "Alarm event has been queued for processing"
+        eventId:
+          type: string
+          description: Unifi Protect event identifier
+          example: "67b389ab005ec703e40075a5"
+        device:
+          type: string
+          description: Device MAC address that triggered the event
+          example: "28704E113F33"
+        processingDelay:
+          type: integer
+          description: Delay in seconds before processing begins
+          example: 120
+        messageId:
+          type: string
+          description: SQS message identifier for tracking
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        estimatedProcessingTime:
+          type: string
+          description: Estimated time when processing will begin (UTC)
+          example: "2025-01-17T20:47:56 UTC"
+
+    ErrorResponse:
+      type: object
+      required:
+        - msg
+      properties:
+        msg:
+          type: string
+          description: |
+            Descriptive error message explaining what went wrong.
+            Includes error code (400, 500, etc.) and specific details for troubleshooting.
+          example: "ERROR 400: malformed or invalid request format"
+
+    VideoDownloadResponse:
+      type: object
+      required:
+        - downloadUrl
+        - filename
+        - videoKey
+        - eventKey
+        - eventId
+        - timestamp
+        - eventDate
+        - expiresAt
+        - message
+      properties:
+        downloadUrl:
+          type: string
+          format: uri
+          description: |
+            Presigned S3 URL for direct video download. Valid for 1 hour.
+            Use this URL to download the video file directly from S3.
+          example: "https://s3.amazonaws.com/bucket/2025-01-17/28704E113F33_1739819436108.mp4?X-Amz-Signature=..."
+        filename:
+          type: string
+          description: |
+            Suggested filename for the downloaded video file.
+            Format: event_{eventId}_{YYYY-MM-DD_HH-mm-ss}.mp4
+          example: "event_67b389ab005ec703e40075a5_2025-01-17_20-43-56.mp4"
+        videoKey:
+          type: string
+          description: |
+            S3 object key for the video file.
+            Format: {YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.mp4
+          example: "2025-01-17/28704E113F33_1739819436108.mp4"
+        eventKey:
+          type: string
+          description: |
+            S3 object key for the corresponding event JSON data.
+            Format: {YYYY-MM-DD}/{eventId}_{deviceMac}_{timestamp}.json
+          example: "2025-01-17/28704E113F33_1739819436108.json"
+        eventId:
+          type: string
+          description: |
+            Unifi Protect event identifier that was searched for.
+          example: "67b389ab005ec703e40075a5"
+        timestamp:
+          type: integer
+          format: int64
+          description: |
+            Unix timestamp (milliseconds) when the event occurred.
+          example: 1739819436108
+        eventDate:
+          type: string
+          description: |
+            Human-readable event date and time in format: YYYY-MM-DD HH:mm:ss
+          example: "2025-01-17 20:43:56"
+        expiresAt:
+          type: string
+          description: |
+            When the download URL expires in format: YYYY-MM-DD HH:mm:ss UTC
+          example: "2025-01-17 21:43:56 UTC"
+        eventData:
+          type: object
+          description: |
+            Complete alarm event details from the corresponding JSON file.
+            Includes device information, trigger details, zones, and all metadata.
+          properties:
+            name:
+              type: string
+              example: "Motion Detection Alert"
+            timestamp:
+              type: integer
+              format: int64
+              example: 1739819436108
+            triggers:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    example: "motion"
+                  device:
+                    type: string
+                    example: "28704E113F33"
+                  eventId:
+                    type: string
+                    example: "67b389ab005ec703e40075a5"
+                  deviceName:
+                    type: string
+                    example: "Backyard West"
+                  zones:
+                    type: object
+        message:
+          type: string
+          description: |
+            Instructions for using the download URL and expiration information.
+          example: "Use the downloadUrl to download the video file directly. URL expires in 1 hour."
+
+tags:
+  - name: Alarm Events
+    description: |
+      Processing of incoming alarm webhook events from Unifi Protect systems.
+      
+      **Typical Flow:**
+      1. Unifi Protect detects motion/person/vehicle
+      2. Alarm rule evaluates conditions
+      3. Webhook sent to this API
+      4. Event processed and stored in S3
+      5. Success response returned to Unifi
+      
+  - name: Event Retrieval
+    description: |
+      Retrieval of stored alarm events for analysis and integration.
+      
+      **Use Cases:**
+      - Dashboard integration
+      - Historical analysis
+      - Event correlation
+      - Audit trails
+      
+  - name: Video Retrieval
+    description: |
+      Direct access to video files associated with alarm events.
+      
+      **Features:**
+      - Optimized search using date-organized folder structure
+      - Efficient backwards chronological search algorithm
+      - Binary MP4 file download with proper headers
+      - Automatic filename suggestion based on event timestamp
+      
+      **Use Cases:**
+      - Quick access to recent security footage
+      - Mobile security applications
+      - Automated monitoring and alerting
+      - Integration with third-party security systems
+      
+  - name: CORS
+    description: |
+      Cross-Origin Resource Sharing support for web applications.
+      
+      **Supported Origins:** All origins (`*`)
+      **Supported Methods:** GET, POST, OPTIONS
+      **Supported Headers:** Content-Type, X-API-Key
+
+externalDocs:
+  description: |
+    Complete project documentation including setup, deployment, and troubleshooting guides.
+  url: https://github.com/engineerthefuture/unifi-protect-event-backup-api/blob/main/README.md


### PR DESCRIPTION
The OpenAPI specification file was moved from the project root to docs/openapi.yaml. All references in readme.md were updated to point to the new location. A copy of the OpenAPI spec was also added to ui/openapi.yaml for UI purposes, and the old root file now contains a notice about the move.