### PR TITLE
update static pages action

### DIFF
--- a/.github/workflows/static-pages.yml
+++ b/.github/workflows/static-pages.yml
@@ -33,11 +33,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Set API index as default
+        run: |
+          cp docs/api/index.html docs/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow for deploying static pages. The main update ensures that the API documentation index is used as the default landing page when deploying to GitHub Pages.

Deployment workflow improvements:

* The workflow now copies `docs/api/index.html` to `docs/index.html` so that the API index becomes the default page on the deployed site. (`.github/workflows/static-pages.yml`)
* The artifact upload step now only uploads the `docs` directory instead of the entire repository, streamlining the deployment. (`.github/workflows/static-pages.yml`)