### PR TITLE
Update Pages deploy workflow branch triggers

### DIFF
--- a/.github/workflows/static-pages.yml
+++ b/.github/workflows/static-pages.yml
@@ -4,7 +4,12 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - 'feature-**'
+      - 'bugfix-**'
+      - 'hotfix-**'
+      - dev
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The workflow now triggers on pushes to 'main', 'dev', and any branches matching 'feature-**', 'bugfix-**', or 'hotfix-**'. This allows for deployment testing and automation on additional branch types.