### PR TITLE
Copy Swagger UI assets to docs root in workflow

### DIFF
--- a/.github/workflows/static-pages.yml
+++ b/.github/workflows/static-pages.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Set API index as default
+      - name: Copy Swagger UI assets to docs root
         run: |
-          cp docs/api/index.html docs/index.html
+          cp -r docs/api/* docs/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Updated the static-pages GitHub Actions workflow to copy all Swagger UI assets from docs/api to the docs root directory, instead of only copying index.html. This ensures all necessary assets are available at the root for static site deployment.