### PR TITLE
Update Swagger UI to use local openapi.yaml path

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -8,6 +8,10 @@ on:
       - 'feature-**'
       - 'bugfix-**'
       - 'hotfix-**'
+    paths:
+      - 'ui/**'
+      - 'templates/ui-cf-stack.yaml'
+      - '.github/workflows/deploy-ui.yml'
 
 jobs:
   deploy-ui:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ on:
       - 'bugfix-**'
       - 'hotfix-**'
       - dev
+    paths:
+      - 'src/**'
+      - 'templates/cf-stack-cs.yaml'
+      - '.github/workflows/deploy.yml'
 
 jobs:
   # Build job: Compiles code, runs tests, and prepares deployment artifacts

--- a/docs/api/swagger-initializer.js
+++ b/docs/api/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
     // the following lines will be replaced by docker/configurator, when it runs in a docker-container
     window.ui = SwaggerUIBundle({
-    url: "openapi.yaml",
+        url: "openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
Changed the Swagger UI configuration to reference 'openapi.yaml' instead of '../openapi.yaml' for the API documentation. This ensures the correct file is loaded when running in the current directory structure.