### PR TITLE
Update Pages workflow to upload docs/api directory

### DIFF
--- a/.github/workflows/static-pages.yml
+++ b/.github/workflows/static-pages.yml
@@ -37,13 +37,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Copy Swagger UI assets to docs root
-        run: |
-          cp -r docs/api/* docs/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'docs'
+          path: 'docs/api'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Removes the step copying Swagger UI assets to the docs root and changes the upload path to 'docs/api' in the GitHub Actions workflow for static pages.