### PR TITLE
Update workflow to copy openapi.yaml and remove index.html

### DIFF
--- a/.github/workflows/static-pages.yml
+++ b/.github/workflows/static-pages.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Copy openapi.yaml to api folder
+        run: cp docs/openapi.yaml docs/api/openapi.yaml
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The static-pages GitHub Actions workflow now copies openapi.yaml to the api folder before uploading artifacts. Also, docs/index.html has been removed from the repository.