### PR TITLE
Update Swagger UI link and fix S3StorageServiceTests assertions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -527,7 +527,7 @@ Fetches and stores current camera metadata from the Unifi Protect API
 
 **Complete API Documentation:**
 - [docs/openapi.yaml](docs/openapi.yaml) (OpenAPI 3.0 spec)
-- [Swagger UI (OpenAPI) – GitHub Pages](https://engineerthefuture.github.io/unifi-protect-event-backup-api/api/index.html)
+- [Swagger UI (OpenAPI) – GitHub Pages](https://engineerthefuture.github.io/unifi-protect-event-backup-api/)
 
 The full OpenAPI 3.0 specification is available in the [`docs/openapi.yaml`](docs/openapi.yaml) file and includes:
 

--- a/test/S3StorageServiceTests.cs
+++ b/test/S3StorageServiceTests.cs
@@ -74,8 +74,12 @@ namespace UnifiWebhookEventReceiverTests
                 Assert.Equal(deviceId, cam["cameraId"]);
                 Assert.Equal(deviceName, cam["cameraName"]);
                 Assert.Equal(1, cam["count24h"]);
-                Assert.Equal("https://presigned-url/video.mp4", cam["lastVideoUrl"]);
-                Assert.True(cam["lastEvent"] != null);
+                var events = cam["events"] as Newtonsoft.Json.Linq.JArray;
+                Assert.NotNull(events);
+                Assert.Single(events);
+                var evt = events[0];
+                Assert.Equal("https://presigned-url/video.mp4", evt["videoUrl"]);
+                Assert.True(evt["eventData"] != null);
                 Assert.NotNull(body["totalCount"]);
                 Assert.Equal(1, (int)(body["totalCount"] ?? 0));
             }


### PR DESCRIPTION
Updated the Swagger UI link in the readme to remove the extra path segment. Modified S3StorageServiceTests to assert on the structure of the 'events' array and its contents instead of direct properties on the camera object.