### PR TITLE
Handle additional S3 error code for missing video

### DIFF
--- a/src/Services/Implementations/S3StorageService.cs
+++ b/src/Services/Implementations/S3StorageService.cs
@@ -176,9 +176,16 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                                 await _s3Client.GetObjectMetadataAsync(headRequest);
                                 videoExists = true;
                             }
-                            catch (AmazonS3Exception e) when (e.ErrorCode == "NoSuchKey")
+                            catch (AmazonS3Exception e) when (e.ErrorCode == "NoSuchKey" || e.ErrorCode == "NotFound")
                             {
+                                // Treat as missing video, do not log as error
                                 videoExists = false;
+                            }
+                            catch (AmazonS3Exception e)
+                            {
+                                // Log and skip only for other S3 errors
+                                _logger.LogLine($"Error checking video existence for {videoKey}: {e.Message}");
+                                continue;
                             }
 
                             var sanitizedAlarm = CloneAlarmWithoutSourcesAndConditions(alarm);


### PR DESCRIPTION
Expanded the catch block to treat both 'NoSuchKey' and 'NotFound' S3 error codes as missing video, preventing unnecessary error logging. Other AmazonS3Exceptions are now logged and skipped.