### PR TITLE
Make retention period configurable via environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -554,6 +554,7 @@ jobs:
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \
               BuildTimestamp="${{ steps.timestamp.outputs.BUILD_TIMESTAMP }}" \
+              RetentionDays="${{ env.MAX_RETENTION_DAYS }}" \
             --tags \
               Owner="${{ vars.OWNER_NAME }}" \
               AppName="${{ vars.APP_NAME }}" \

--- a/src/Configuration/AppConfiguration.cs
+++ b/src/Configuration/AppConfiguration.cs
@@ -1,4 +1,5 @@
 
+
 /************************
  * Unifi Webhook Event Receiver
  * AppConfiguration.cs
@@ -22,6 +23,8 @@ namespace UnifiWebhookEventReceiver.Configuration
     /// </summary>
     public static class AppConfiguration
     {
+        /// <summary>Maximum retention period (in days) for event data, matching S3 lifecycle rule.</summary>
+        public static int MaxRetentionDays => int.TryParse(Environment.GetEnvironmentVariable("MaxRetentionDays"), out var days) ? days : 30;
         #region Constants
 
         /// <summary>Error message template for 500 Internal Server Error responses</summary>

--- a/src/Services/Implementations/S3StorageService.cs
+++ b/src/Services/Implementations/S3StorageService.cs
@@ -506,10 +506,9 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             _logger.LogLine("Searching for latest video file in S3 bucket using date-organized approach: " + AppConfiguration.AlarmBucketName);
 
             DateTime searchDate = DateTime.UtcNow.Date;
-            const int maxDaysToSearch = 30;
             int daysSearched = 0;
 
-            while (daysSearched < maxDaysToSearch)
+            while (daysSearched < AppConfiguration.MaxRetentionDays)
             {
                 string dateFolder = searchDate.ToString("yyyy-MM-dd");
                 _logger.LogLine($"Searching for videos in date folder: {dateFolder}");
@@ -709,10 +708,9 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             _logger.LogLine($"Searching for event file with eventId prefix: {eventId}");
 
             DateTime searchDate = DateTime.UtcNow.Date;
-            const int maxDaysToSearch = 90;
             int daysSearched = 0;
 
-            while (daysSearched < maxDaysToSearch)
+            while (daysSearched < AppConfiguration.MaxRetentionDays)
             {
                 string dateFolder = searchDate.ToString("yyyy-MM-dd");
                 _logger.LogLine($"Searching for eventId {eventId} in date folder: {dateFolder}");
@@ -725,7 +723,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
                 searchDate = searchDate.AddDays(-1);
                 daysSearched++;
             }
-            return (null, null, 0, _responseHelper.CreateErrorResponse(HttpStatusCode.NotFound, $"Event with ID {eventId} not found in the last {maxDaysToSearch} days."));
+            return (null, null, 0, _responseHelper.CreateErrorResponse(HttpStatusCode.NotFound, $"Event with ID {eventId} not found in the last {AppConfiguration.MaxRetentionDays} days."));
         }
 
         private async Task<(string? EventKey, string? VideoKey, long Timestamp)> SearchEventInDateFolderAsync(string eventId, string dateFolder)

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -19,6 +19,11 @@ Metadata:
     
 # Parameters
 Parameters:
+  RetentionDays:
+    Type: Number
+    Description: Number of days to retain event data in S3 and for API search.
+    Default: 30
+    MinValue: 1
   AppName:
     Default: unifi-protect-event-backup-api
     Type: String
@@ -274,8 +279,8 @@ Resources:
               Rules:
                 - Id: DeleteAfter30Days
                   Status: Enabled
-                  ExpirationInDays: 30
-                  NoncurrentVersionExpirationInDays: 30
+                  ExpirationInDays: !Ref RetentionDays
+                  NoncurrentVersionExpirationInDays: !Ref RetentionDays
             Tags: 
               - Key: "Name"
                 Value: !Sub "${BucketName}"
@@ -607,6 +612,7 @@ Resources:
           SupportEmail: !Ref SupportEmail
           BuildSha: !Ref BuildSha
           BuildTimestamp: !Ref BuildTimestamp
+          MaxRetentionDays: !Ref RetentionDays
       Tags: 
         - Key: "FunctionName"
           Value: !Sub "${FunctionName}"


### PR DESCRIPTION
Introduces a configurable MaxRetentionDays parameter for event data retention, replacing hardcoded values in S3 lifecycle rules and API search logic. Updates CloudFormation template, deployment workflow, and application code to use the new parameter, allowing retention period to be set via environment variable and stack parameter.