### PR TITLE
Fix RetentionDays quoting in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -554,7 +554,7 @@ jobs:
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \
               BuildTimestamp="${{ steps.timestamp.outputs.BUILD_TIMESTAMP }}" \
-              RetentionDays="${{ env.MAX_RETENTION_DAYS }}" \
+              RetentionDays=${{ env.MAX_RETENTION_DAYS }} \
             --tags \
               Owner="${{ vars.OWNER_NAME }}" \
               AppName="${{ vars.APP_NAME }}" \


### PR DESCRIPTION
Removed unnecessary quotes around the RetentionDays environment variable in the deploy.yml workflow to ensure correct value substitution.