### PR TITLE
Use vars for RetentionDays in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -554,7 +554,7 @@ jobs:
               HostedZoneId="${{ steps.env.outputs.HOSTED_ZONE_ID }}" \
               BuildSha="${{ github.sha }}" \
               BuildTimestamp="${{ steps.timestamp.outputs.BUILD_TIMESTAMP }}" \
-              RetentionDays=${{ env.MAX_RETENTION_DAYS }} \
+              RetentionDays=${{ vars.MAX_RETENTION_DAYS }} \
             --tags \
               Owner="${{ vars.OWNER_NAME }}" \
               AppName="${{ vars.APP_NAME }}" \


### PR DESCRIPTION
Updated the deploy.yml workflow to reference RetentionDays from the vars context instead of env. This ensures consistency with other variable usages in the workflow.