### PR TITLE
Updated cognito prefix to be per env

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -160,7 +160,7 @@ jobs:
               AuthorizationLambdaEdgeS3Key="$AUTH_LAMBDA_EDGE_S3_KEY" \
               LambdaEdgeCodeSha="$LAMBDA_EDGE_CODE_SHA" \
               LambdaEdgeHex="$LAMBDA_EDGE_HEX" \
-              CognitoDomainPrefix="${{ vars.COGNITO_DOMAIN_PREFIX }}" \
+              CognitoDomainPrefix="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}" \
             --tags \
               Owner="${{ vars.OWNER_NAME }}" \
               AppName="${{ vars.APP_NAME_UI }}" \
@@ -190,3 +190,10 @@ jobs:
             --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
             --output text)
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
+
+      - name: Print CloudFormation stack events on failure
+        if: failure()
+        run: |
+          STACK_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}
+          echo "Fetching CloudFormation stack events for $STACK_NAME..."
+          aws cloudformation describe-stack-events --stack-name $STACK_NAME || true


### PR DESCRIPTION
This pull request updates the `deploy-ui.yml` GitHub Actions workflow to improve environment naming consistency and add better troubleshooting support for deployment failures. The most important changes are:

**Environment Naming Consistency:**
* Updated the `CognitoDomainPrefix` parameter to use the format `bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}` instead of just `${{ vars.COGNITO_DOMAIN_PREFIX }}` for clearer and more consistent environment-based naming.

**Deployment Failure Troubleshooting:**
* Added a new step to print CloudFormation stack events if the deployment job fails, making it easier to diagnose issues by automatically fetching and displaying recent stack events for the relevant stack.Updated cognito prefix to be per env