### PR TITLE
Remove ApiGatewayProxyMethodOptions resource

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -491,42 +491,6 @@ Resources:
         ResponseParameters:
           method.response.header.Access-Control-Allow-Origin: true
 
-  # Proxy method for Options
-  ApiGatewayProxyMethodOptions:
-    Type: 'AWS::ApiGateway::Method'
-    Properties:
-      HttpMethod: OPTIONS
-      ResourceId: !Ref ApiGatewayResource
-      RestApiId: !Ref ApiGateway
-      ApiKeyRequired: false
-      AuthorizationType: NONE
-      RequestParameters:
-        method.request.path.proxy: true
-      Integration:
-        IntegrationResponses:
-        - StatusCode: 200
-          ResponseParameters:
-            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Origin,Access-Control-Allow-Origin,Access-Control-Allow-Methods'"
-            method.response.header.Access-Control-Allow-Methods: "'GET,POST,OPTIONS'"
-            method.response.header.Access-Control-Allow-Origin: "'*'"
-        CacheKeyParameters:
-          - 'method.request.path.proxy'
-        ContentHandling: "CONVERT_TO_TEXT"
-        RequestParameters:
-          integration.request.path.proxy: 'method.request.path.proxy'
-        IntegrationHttpMethod: POST
-        Type: AWS_PROXY
-        Uri: !Join
-                  - ''
-                  - - !Sub arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:${AWS::AccountId}:function
-                    - !Sub :${FunctionName}/invocations
-        PassthroughBehavior: WHEN_NO_MATCH
-      MethodResponses:
-      - StatusCode: 200
-        ResponseParameters:
-          method.response.header.Access-Control-Allow-Headers: true
-          method.response.header.Access-Control-Allow-Methods: true
-          method.response.header.Access-Control-Allow-Origin: true
 
 
   # API gateway deployment


### PR DESCRIPTION
Deleted the ApiGatewayProxyMethodOptions resource from the CloudFormation template, which defined an OPTIONS method for the API Gateway proxy. This may be part of a cleanup or refactor to simplify CORS handling or remove unused resources.