### PR TITLE
Remove OPTIONS method from API Gateway deployment

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -499,7 +499,6 @@ Resources:
       - ApiGatewayRootMethod
       - ApiGatewayProxyMethodGet
       - ApiGatewayProxyMethodPost
-      - ApiGatewayProxyMethodOptions
     Type: 'AWS::ApiGateway::Deployment'
     Properties:
       RestApiId: !Ref ApiGateway


### PR DESCRIPTION
The ApiGatewayProxyMethodOptions resource was removed from the list of dependencies for the AWS::ApiGateway::Deployment resource. This change may be intended to prevent deployment from waiting on the OPTIONS method or to remove unused method integration.