### PR TITLE
Use environment-specific UI API keys in deploy workflow

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -186,7 +186,7 @@ jobs:
               LambdaEdgeCodeSha="$LAMBDA_EDGE_CODE_SHA" \
               LambdaEdgeHex="$LAMBDA_EDGE_HEX" \
               CognitoDomainPrefix="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}" \
-              UiApiKey="${{ secrets.UI_API_KEY }}" \
+              UiApiKey="${{ github.ref_name == 'main' && secrets.PROD_UI_API_KEY || secrets.DEV_UI_API_KEY }}" \
             --tags \
               Owner="${{ vars.OWNER_NAME }}" \
               AppName="${{ vars.APP_NAME_UI }}" \
@@ -210,7 +210,11 @@ jobs:
           API_STACK_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-event-backup-api
           API_URL=$(aws cloudformation describe-stacks --stack-name $API_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='GETSummaryEndpoint'].OutputValue" --output text)
           # Get UI API key from repository secrets instead of CloudFormation outputs
-          API_KEY="${{ secrets.UI_API_KEY }}"
+          if [[ "${{ steps.env.outputs.ENV_PREFIX }}" == "prod" ]]; then
+            API_KEY="${{ secrets.PROD_UI_API_KEY }}"
+          else
+            API_KEY="${{ secrets.DEV_UI_API_KEY }}"
+          fi
           echo "API_URL=$API_URL" >> $GITHUB_ENV
           echo "API_KEY=$API_KEY" >> $GITHUB_ENV
           echo "API endpoint for UI: $API_URL"


### PR DESCRIPTION
Updated the deploy-ui GitHub Actions workflow to select the appropriate UI API key based on the branch or environment. This ensures production and development deployments use their respective secrets for improved security and separation.