### PR TITLE
Add exposed headers to allow for video thumbnails on UI

### DIFF
--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -232,6 +232,12 @@ Resources:
               - GET
             AllowedOrigins:
               - '*'
+            ExposeHeaders:
+              - Content-Range
+              - Accept-Ranges
+              - Content-Encoding
+              - Content-Length
+              - ETag
             Id: OpenCors
             MaxAge: '3600'
       Tags:

--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -232,7 +232,7 @@ Resources:
               - GET
             AllowedOrigins:
               - '*'
-            ExposeHeaders:
+            ExposedHeaders:
               - Content-Range
               - Accept-Ranges
               - Content-Encoding


### PR DESCRIPTION
This pull request makes a small update to the CORS configuration in the `ui-cf-stack.yaml` template. The change exposes additional HTTP headers to clients, which can be useful for handling range requests and caching in web applications.

- Added `ExposedHeaders` to the CORS configuration, allowing the following headers to be accessed by browsers: `Content-Range`, `Accept-Ranges`, `Content-Encoding`, `Content-Length`, and `ETag`.