### PR TITLE
Add CORS configuration to S3 bucket in CloudFormation

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -309,6 +309,22 @@ Resources:
               BlockPublicPolicy: true
               IgnorePublicAcls: true
               RestrictPublicBuckets: true
+              CorsConfiguration:
+            CorsRules:
+              - AllowedHeaders:
+                  - '*'
+                AllowedMethods:
+                  - GET
+                AllowedOrigins:
+                  - '*'
+                ExposedHeaders:
+                  - Content-Range
+                  - Accept-Ranges
+                  - Content-Encoding
+                  - Content-Length
+                  - ETag
+                Id: OpenCors
+                MaxAge: '3600'
             LifecycleConfiguration:
               Rules:
                 - Id: DeleteAfter30Days


### PR DESCRIPTION
Introduced a CORS configuration allowing GET requests from any origin with all headers permitted and specific exposed headers. This change enables cross-origin access to the S3 bucket resources as defined in the CloudFormation template.