### PR TITLE
Fix formatting in architecture diagram section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ The lifecycle rule applies to both JSON event files and MP4 video files, ensurin
 ## 🏛️ Architecture
 
 ```mermaid
+
 flowchart TD
   subgraph User
     BROWSER[User's Browser]


### PR DESCRIPTION
Added a missing newline before the Mermaid diagram in the architecture section of the readme for improved formatting.