### PR TITLE
Remove readme and license from deploy workflow triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,6 @@ on:
       - 'UnifiWebhookEventReceiver.sln'
       - 'aws-lambda-tools-defaults.json'
       - 'global.json'
-      - 'readme.md'
-      - 'LICENSE'
 
 jobs:
   # Build job: Compiles code, runs tests, and prepares deployment artifacts


### PR DESCRIPTION
Updates the deploy workflow to no longer trigger on changes to readme.md or LICENSE files, reducing unnecessary deployments for documentation or license updates.