### PR TITLE
Add CustomGETSummaryEndpoint output to CloudFormation

### DIFF
--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -741,6 +741,10 @@ Outputs:
     Condition: UseCustomDomain
     Description: GET endpoint for fetching and storing camera metadata from Unifi Protect (Custom Domain)
     Value: !Sub "${DomainName}/${EnvPrefix}/metadata"
+  CustomGETSummaryEndpoint:
+    Condition: UseCustomDomain
+    Description: GET endpoint for retrieving the summary data for the UI (Custom Domain)
+    Value: !Sub "${DomainName}/${EnvPrefix}/summary"
   DomainNameTarget:
     Condition: UseCustomDomain
     Description: Target domain name for DNS CNAME record


### PR DESCRIPTION
Introduces a new output, CustomGETSummaryEndpoint, to the CloudFormation template for exposing the summary data GET endpoint when using a custom domain.