### PR TITLE
Switched to dns hostnames for redirects and links and implemented a timeout redirect on token expiry

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -235,9 +235,10 @@ jobs:
           COGNITO_DOMAIN_PREFIX="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}"
           COGNITO_DOMAIN="https://$COGNITO_DOMAIN_PREFIX.auth.us-east-1.amazoncognito.com"
           REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
-          REDIRECT_URI_ENC=$(python3 -c "import urllib.parse; print(urllib.parse.quote('https://$CLOUDFRONT_DOMAIN/auth-callback.html'))")
-          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$REDIRECT_URI_ENC"
-          sed -i.bak "s|var loginUrl = '%%COGNITO_LOGIN_URL%%';|var loginUrl = '$LOGIN_URL';|g" ui/main.js
+          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri="
+          sed -i "s|%%COGNITO_REPLACEMENT%%|$LOGIN_URL|g" ui/main.js
+          sed -i "s|%%REDIRECT_URI%%|$REDIRECT_URI|g" ui/main.js
+          
 
       - name: Copy UI contents to S3 bucket
         run: |

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -235,9 +235,9 @@ jobs:
           COGNITO_DOMAIN_PREFIX="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}"
           COGNITO_DOMAIN="https://$COGNITO_DOMAIN_PREFIX.auth.us-east-1.amazoncognito.com"
           REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
-          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri="
-          sed -i "s|%%COGNITO_REPLACEMENT%%|$LOGIN_URL|g" ui/main.js
-          sed -i "s|%%REDIRECT_URI%%|$REDIRECT_URI|g" ui/main.js
+          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$REDIRECT_URI"
+          LOGIN_URL_ESCAPED=$(printf '%s' "$LOGIN_URL" | sed 's/&/\\&/g')
+          sed -i "s|%%COGNITO_REPLACEMENT%%|$LOGIN_URL_ESCAPED|g" ui/main.js
           
 
       - name: Copy UI contents to S3 bucket

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -208,7 +208,7 @@ jobs:
         id: api_outputs
         run: |
           API_STACK_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-unifi-protect-event-backup-api
-          API_URL=$(aws cloudformation describe-stacks --stack-name $API_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='GETSummaryEndpoint'].OutputValue" --output text)
+          API_URL=$(aws cloudformation describe-stacks --stack-name $API_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CustomGETSummaryEndpoint'].OutputValue" --output text)
           # Get UI API key from repository secrets instead of CloudFormation outputs
           if [[ "${{ steps.env.outputs.ENV_PREFIX }}" == "prod" ]]; then
             API_KEY="${{ secrets.PROD_UI_API_KEY }}"
@@ -226,6 +226,17 @@ jobs:
             -e "s|%%API_URL%%|$API_URL|g" \
             -e "s|%%API_KEY%%|$API_KEY|g" \
             ui/main.js
+
+      - name: Patch main.js with Cognito login URL
+        run: |
+          STACK_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}
+          CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDomain'].OutputValue" --output text)
+          USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolClientId'].OutputValue" --output text)
+          COGNITO_DOMAIN_PREFIX="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}"
+          COGNITO_DOMAIN="https://$COGNITO_DOMAIN_PREFIX.auth.us-east-1.amazoncognito.com"
+          REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
+          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["REDIRECT_URI"]))')"
+          sed -i.bak "s|%%COGNITO_LOGIN_URL%%|$LOGIN_URL|g" ui/main.js
 
       - name: Copy UI contents to S3 bucket
         run: |

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -234,7 +234,7 @@ jobs:
           USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolClientId'].OutputValue" --output text)
           COGNITO_DOMAIN_PREFIX="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}"
           COGNITO_DOMAIN="https://$COGNITO_DOMAIN_PREFIX.auth.us-east-1.amazoncognito.com"
-          REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
+          export REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
           LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["REDIRECT_URI"]))')"
           sed -i.bak "s|%%COGNITO_LOGIN_URL%%|$LOGIN_URL|g" ui/main.js
 

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -230,12 +230,13 @@ jobs:
       - name: Patch main.js with Cognito login URL
         run: |
           STACK_NAME=bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}
-          CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDomain'].OutputValue" --output text)
+          CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CustomCloudFrontDomain'].OutputValue" --output text)
           USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='CognitoUserPoolClientId'].OutputValue" --output text)
           COGNITO_DOMAIN_PREFIX="bf-${{ steps.env.outputs.ENV_PREFIX }}-${{ vars.APP_NAME_UI }}"
           COGNITO_DOMAIN="https://$COGNITO_DOMAIN_PREFIX.auth.us-east-1.amazoncognito.com"
-          export REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
-          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$(python3 -c 'import urllib.parse,os; print(urllib.parse.quote(os.environ["REDIRECT_URI"]))')"
+          REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
+          REDIRECT_URI_ENC=$(python3 -c "import urllib.parse; print(urllib.parse.quote('https://$CLOUDFRONT_DOMAIN/auth-callback.html'))")
+          LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$REDIRECT_URI_ENC"
           sed -i.bak "s|%%COGNITO_LOGIN_URL%%|$LOGIN_URL|g" ui/main.js
 
       - name: Copy UI contents to S3 bucket

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -222,6 +222,10 @@ jobs:
 
       - name: Patch UI main.js with API connection details
         run: |
+          # Ensure API_URL is always https://
+          if [[ ! "$API_URL" =~ ^https?:// ]]; then
+            API_URL="https://$API_URL"
+          fi
           sed -i.bak \
             -e "s|%%API_URL%%|$API_URL|g" \
             -e "s|%%API_KEY%%|$API_KEY|g" \

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -237,7 +237,7 @@ jobs:
           REDIRECT_URI="https://$CLOUDFRONT_DOMAIN/auth-callback.html"
           REDIRECT_URI_ENC=$(python3 -c "import urllib.parse; print(urllib.parse.quote('https://$CLOUDFRONT_DOMAIN/auth-callback.html'))")
           LOGIN_URL="$COGNITO_DOMAIN/login?client_id=$USER_POOL_CLIENT_ID&response_type=token&scope=openid&redirect_uri=$REDIRECT_URI_ENC"
-          sed -i.bak "s|%%COGNITO_LOGIN_URL%%|$LOGIN_URL|g" ui/main.js
+          sed -i.bak "s|var loginUrl = '%%COGNITO_LOGIN_URL%%';|var loginUrl = '$LOGIN_URL';|g" ui/main.js
 
       - name: Copy UI contents to S3 bucket
         run: |

--- a/templates/ui-cf-stack.yaml
+++ b/templates/ui-cf-stack.yaml
@@ -188,11 +188,11 @@ Resources:
         - profile
       AllowedOAuthFlowsUserPoolClient: true
       CallbackURLs:
-        - !Sub "https://${WebsiteCloudFront.DomainName}/auth-callback.html"
         - !If [HasCustomDomain, !Sub "https://${DomainName}/auth-callback.html", !Ref "AWS::NoValue"]
+        - !Sub "https://${WebsiteCloudFront.DomainName}/auth-callback.html"
       LogoutURLs:
-        - !Sub "https://${WebsiteCloudFront.DomainName}/auth-callback.html"
         - !If [HasCustomDomain, !Sub "https://${DomainName}/auth-callback.html", !Ref "AWS::NoValue"]
+        - !Sub "https://${WebsiteCloudFront.DomainName}/auth-callback.html"
 
   # ACM Certificate for custom domain (DNS validated)
   Certificate:
@@ -381,3 +381,8 @@ Outputs:
   CognitoUserPoolClientId:
     Description: "Cognito User Pool Client ID"
     Value: !Ref CognitoUserPoolClient
+
+  # Custom CloudFront domain (the custom domain name used in Route53 A record)
+  CustomCloudFrontDomain:
+    Description: "Custom CloudFront domain name"
+    Value: !Ref DomainName

--- a/ui/main.js
+++ b/ui/main.js
@@ -11,10 +11,7 @@
 
 // Injected at deploy time by workflow:
 window.__CONFIG__ = {
-    API_URL: (function(url) {
-        if (!/^https?:\/\//.test(url)) return 'https://' + url;
-        return url;
-    })('%%API_URL%%'), // PATCHED BY WORKFLOW
+    API_URL: '%%API_URL%%', // PATCHED BY WORKFLOW
     API_KEY: '%%API_KEY%%' // PATCHED BY WORKFLOW
 };
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -36,7 +36,7 @@ window.__CONFIG__ = {
         }
     }
     var token = getCookie('CognitoAccessToken');
-    var loginUrl = '%%COGNITO_REPLACEMENT%%' + '%%REDIRECT_URI%%';
+    var loginUrl = '%%COGNITO_REPLACEMENT%%';
     if (!token || isJwtExpired(token)) {
         window.location.replace(loginUrl);
     }

--- a/ui/main.js
+++ b/ui/main.js
@@ -15,6 +15,33 @@ window.__CONFIG__ = {
     API_KEY: '%%API_KEY%%' // PATCHED BY WORKFLOW
 };
 
+/************************
+ * Cognito token check: redirect to login if missing or expired
+ */
+(function() {
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+
+    function isJwtExpired(token) {
+        try {
+            const payload = JSON.parse(atob(token.split('.')[1]));
+            if (!payload.exp) return true;
+            // exp is in seconds since epoch
+            return (Date.now() / 1000) > payload.exp;
+        } catch (e) {
+            return true;
+        }
+    }
+    var token = getCookie('CognitoAccessToken');
+    var loginUrl = '%%COGNITO_LOGIN_URL%%';
+    if (!token || isJwtExpired(token)) {
+        window.location.replace(loginUrl);
+    }
+})();
+
 // Fetch summary data from the API
 async function fetchSummary() {
     const { API_URL, API_KEY } = window.__CONFIG__;

--- a/ui/main.js
+++ b/ui/main.js
@@ -11,7 +11,10 @@
 
 // Injected at deploy time by workflow:
 window.__CONFIG__ = {
-    API_URL: '%%API_URL%%', // PATCHED BY WORKFLOW
+    API_URL: (function(url) {
+        if (!/^https?:\/\//.test(url)) return 'https://' + url;
+        return url;
+    })('%%API_URL%%'), // PATCHED BY WORKFLOW
     API_KEY: '%%API_KEY%%' // PATCHED BY WORKFLOW
 };
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -36,7 +36,7 @@ window.__CONFIG__ = {
         }
     }
     var token = getCookie('CognitoAccessToken');
-    var loginUrl = '%%COGNITO_LOGIN_URL%%';
+    var loginUrl = '%%COGNITO_REPLACEMENT%%' + '%%REDIRECT_URI%%';
     if (!token || isJwtExpired(token)) {
         window.location.replace(loginUrl);
     }


### PR DESCRIPTION
This pull request introduces several improvements to the authentication flow and deployment process for the UI, focusing on integrating Cognito-based login, ensuring correct API endpoint usage, and enhancing CloudFormation outputs. The most significant changes are the addition of a Cognito token check and login redirect in the UI, dynamic patching of authentication and API details during deployment, and updates to CloudFormation templates to support these features.

**Authentication and Login Flow Enhancements:**

* Added a self-invoking function in `ui/main.js` to check for a valid `CognitoAccessToken` cookie and redirect to the Cognito login page if the token is missing or expired. The login URL is dynamically injected during deployment.
* Introduced a new deployment step in `.github/workflows/deploy-ui.yml` to patch `main.js` with the correct Cognito login URL, constructed from CloudFormation stack outputs and environment variables.

**Deployment and API Configuration Improvements:**

* Updated the workflow in `.github/workflows/deploy-ui.yml` to ensure the `API_URL` is always prefixed with `https://`, and switched the CloudFormation output key for the API endpoint to `CustomGETSummaryEndpoint`. [[1]](diffhunk://#diff-412c5bee417464cb51f1591872dcad75d29e9d460fc8c9085b280c12d961e2dbL211-R211) [[2]](diffhunk://#diff-412c5bee417464cb51f1591872dcad75d29e9d460fc8c9085b280c12d961e2dbR225-R246)

**CloudFormation Template Updates:**

* Modified `templates/ui-cf-stack.yaml` to ensure both callback and logout URLs for Cognito include the CloudFront domain and the custom domain (if present), improving compatibility with different deployment scenarios.
* Added a new output `CustomCloudFrontDomain` to the CloudFormation template to expose the custom CloudFront domain name for use in deployment scripts.