### PR TITLE
Move response401 definition after responseRedirect

### DIFF
--- a/authorization-lambda-at-edge/src/index.js
+++ b/authorization-lambda-at-edge/src/index.js
@@ -40,9 +40,6 @@ for (var i = 0; i < keys.length; i++) {
     pems[key_id] = pem;
 }
 
-// Standard 401 Unauthorized response for CloudFront
-// Standard 401 Unauthorized response for CloudFront (not used for UI, always redirect instead)
-const response401 = responseRedirect;
 
 // Cognito Hosted UI domain and client ID (replace with your values or set as env variables)
 const cognitoDomain = '##COGNITO_DOMAIN##';
@@ -60,6 +57,9 @@ const responseRedirect = {
     },
     body: ''
 };
+
+// Standard 401 Unauthorized response for CloudFront (not used for UI, always redirect instead)
+const response401 = responseRedirect;
 
 console.log('Lambda@Edge Auth Function starting');
 console.log('Deployed version: ##LAMBDA_EDGE_HEX## at ##LAMBDA_EDGE_DEPLOY_TS##');


### PR DESCRIPTION
Reordered the declaration of response401 to appear after responseRedirect, ensuring responseRedirect is defined before being assigned. This improves code clarity and prevents potential reference errors.