### PR TITLE
Trigger deploy-ui workflow on auth lambda changes

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -10,6 +10,7 @@ on:
       - 'hotfix-**'
     paths:
       - 'ui/**'
+      - 'authorization-lambda-at-edge/**'
       - 'templates/ui-cf-stack.yaml'
       - '.github/workflows/deploy-ui.yml'
 


### PR DESCRIPTION
Updated the deploy-ui GitHub Actions workflow to also trigger when files in the 'authorization-lambda-at-edge' directory are modified. This ensures deployments are run when relevant authorization code changes.