### PR TITLE
Updated summary lambda role name to shorten it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,11 +88,16 @@ jobs:
         env:
           CI: true
 
+      - name: Debug - List test-results directory
+        run: |
+          ls -l summary-event-lambda/test-results || true
+          cat summary-event-lambda/test-results/js-junit.xml || true
+
       - name: Upload JS unit test results
         uses: actions/upload-artifact@v4
         with:
           name: js-test-results
-          path: summary-event-lambda/test-results/js-junit.xml
+          path: summary-event-lambda/test-results/
 
       - name: Post JS unit test summary
         if: always()

--- a/templates/cf-stack-cs.yaml
+++ b/templates/cf-stack-cs.yaml
@@ -187,7 +187,7 @@ Resources:
   SummaryLambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${FunctionName}-summary-lambda-role"
+      RoleName: !Sub "${FunctionName}-sum-role"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
This pull request introduces a couple of targeted improvements to the deployment workflow and infrastructure naming conventions. The most notable changes are the addition of a debugging step for test results in the deployment workflow and a simplification of an IAM role's name in the CloudFormation template.

**Deployment workflow enhancements:**

* Added a debug step to the GitHub Actions workflow (`.github/workflows/deploy.yml`) to list the contents of the `test-results` directory and display the `js-junit.xml` file, aiding in troubleshooting test failures.
* Changed the artifact upload step to upload the entire `test-results` directory instead of just the `js-junit.xml` file, ensuring all test-related artifacts are available.

**Infrastructure naming:**

* Updated the IAM role name in the CloudFormation template (`templates/cf-stack-cs.yaml`) from `${FunctionName}-summary-lambda-role` to a shorter `${FunctionName}-sum-role` for improved clarity and brevity.