### PR TITLE
Add thumbnail support and coverage exclusion attribute

### DIFF
--- a/src/Attributes/ExcludeFromCoverageAttribute.cs
+++ b/src/Attributes/ExcludeFromCoverageAttribute.cs
@@ -1,0 +1,47 @@
+/************************
+ * Unifi Webhook Event Receiver
+ * ExcludeFromCoverageAttribute.cs
+ * 
+ * Custom attribute to mark code sections that should be excluded from code coverage.
+ * Primarily used for logging statements and other non-testable code.
+ * 
+ * Author: Brent Foster
+ * Created: 09-07-2025
+ ***********************/
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace UnifiWebhookEventReceiver.Attributes
+{
+    /// <summary>
+    /// Marks code that should be excluded from code coverage calculations.
+    /// This is typically used for logging statements, error handling, and other
+    /// code that doesn't contribute to business logic coverage.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Constructor)]
+    public sealed class ExcludeFromCoverageAttribute : Attribute
+    {
+        /// <summary>
+        /// Optional reason for excluding this code from coverage.
+        /// </summary>
+        public string? Reason { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the ExcludeFromCoverageAttribute.
+        /// </summary>
+        public ExcludeFromCoverageAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ExcludeFromCoverageAttribute with a reason.
+        /// </summary>
+        /// <param name="reason">The reason for excluding this code from coverage.</param>
+        public ExcludeFromCoverageAttribute(string reason)
+        {
+            Reason = reason;
+        }
+    }
+}

--- a/src/Event.cs
+++ b/src/Event.cs
@@ -45,6 +45,9 @@ namespace UnifiWebhookEventReceiver
 
         /// <summary>Local network link to access the event data directly from the Unifi system</summary>
         public string? eventLocalLink { get; set; }
+
+        /// <summary>Base64-encoded thumbnail image data (e.g., "data:image/jpeg;base64,...")</summary>
+        public string? thumbnail { get; set; }
     }
 
     /// <summary>

--- a/src/Extensions/LoggerExtensions.cs
+++ b/src/Extensions/LoggerExtensions.cs
@@ -1,0 +1,35 @@
+/************************
+ * Unifi Webhook Event Receiver
+ * LoggerExtensions.cs
+ * 
+ * Extension methods for ILambdaLogger to provide coverage-excluded logging.
+ * 
+ * Author: Brent Foster
+ * Created: 09-07-2025
+ ***********************/
+
+using System.Diagnostics.CodeAnalysis;
+using Amazon.Lambda.Core;
+using UnifiWebhookEventReceiver.Attributes;
+
+namespace UnifiWebhookEventReceiver.Extensions
+{
+    /// <summary>
+    /// Extension methods for ILambdaLogger that exclude logging calls from code coverage.
+    /// </summary>
+    [ExcludeFromCoverage("Logging extensions should not be included in coverage calculations")]
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Logs a line of text, excluded from code coverage.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="message">The message to log.</param>
+        [ExcludeFromCodeCoverage]
+        [ExcludeFromCoverage("Logging should not be included in coverage calculations")]
+        public static void LogLineExcluded(this ILambdaLogger logger, string message)
+        {
+            logger.LogLine(message);
+        }
+    }
+}

--- a/src/Services/Implementations/AlarmProcessingService.cs
+++ b/src/Services/Implementations/AlarmProcessingService.cs
@@ -164,15 +164,15 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             _logger.LogLine($"Alarm event stored in S3 with key: {eventKey}");
 
             // Store thumbnail if provided
-            if (!string.IsNullOrEmpty(trigger.thumbnail))
+            if (!string.IsNullOrEmpty(alarm.thumbnail))
             {
                 var thumbnailKey = GenerateThumbnailKey(trigger, alarm.timestamp);
                 _logger.LogLine($"Thumbnail data found, storing to S3 with key: {thumbnailKey}");
-                await _s3StorageService.StoreThumbnailAsync(trigger.thumbnail, thumbnailKey);
+                await _s3StorageService.StoreThumbnailAsync(alarm.thumbnail, thumbnailKey);
             }
             else
             {
-                _logger.LogLine("No thumbnail data provided in trigger");
+                _logger.LogLine("No thumbnail data provided in alarm");
             }
 
             // Download and store video if event path is available
@@ -216,12 +216,12 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             _logger.LogLine($"Alarm event stored in S3 with key: {eventKey}");
 
             // Store thumbnail if available
-            if (!string.IsNullOrEmpty(trigger.thumbnail))
+            if (!string.IsNullOrEmpty(alarm.thumbnail))
             {
                 try
                 {
                     var thumbnailKey = GenerateThumbnailKey(trigger, alarm.timestamp);
-                    await _s3StorageService.StoreThumbnailAsync(trigger.thumbnail, thumbnailKey);
+                    await _s3StorageService.StoreThumbnailAsync(alarm.thumbnail, thumbnailKey);
                     _logger.LogLine($"Thumbnail stored in S3 with key: {thumbnailKey}");
                 }
                 catch (Exception ex)
@@ -276,9 +276,9 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             };
             
             // Include thumbnail data in metadata if available
-            if (!string.IsNullOrEmpty(triggerForSummary?.thumbnail))
+            if (!string.IsNullOrEmpty(alarm.thumbnail))
             {
-                summaryEvent.Metadata["thumbnail"] = triggerForSummary.thumbnail;
+                summaryEvent.Metadata["thumbnail"] = alarm.thumbnail;
             }
             
             // Include original filename in metadata if available

--- a/src/Services/Implementations/S3StorageService.cs
+++ b/src/Services/Implementations/S3StorageService.cs
@@ -1217,12 +1217,11 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
             return new Alarm
             {
                 name = alarm.name,
-                sources = null,
-                conditions = null,
                 triggers = alarm.triggers,
                 timestamp = alarm.timestamp,
                 eventPath = alarm.eventPath,
-                eventLocalLink = alarm.eventLocalLink
+                eventLocalLink = alarm.eventLocalLink,
+                thumbnail = alarm.thumbnail
             };
         }
 

--- a/test/AlarmProcessingServiceTests.cs
+++ b/test/AlarmProcessingServiceTests.cs
@@ -635,7 +635,7 @@ namespace UnifiWebhookEventReceiverTests
             // Arrange
             SetValidAlarmBucketEnvironment();
             var alarm = CreateValidAlarm();
-            alarm.triggers[0].thumbnail = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/wAALCAABAAEBAREA/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwBVWX/2Q==";
+            alarm.thumbnail = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/wAALCAABAAEBAREA/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwBVWX/2Q==";
             
             var credentials = new UnifiCredentials { hostname = "unifi.local", username = "admin", password = "password", apikey = "test-key" };
             _mockCredentialsService.Setup(x => x.GetUnifiCredentialsAsync())
@@ -816,6 +816,7 @@ namespace UnifiWebhookEventReceiverTests
             var alarm = new UnifiWebhookEventReceiver.Alarm
             {
                 timestamp = 1672531200000,
+                thumbnail = thumbnailData,
                 triggers = new List<UnifiWebhookEventReceiver.Trigger>
                 {
                     new UnifiWebhookEventReceiver.Trigger
@@ -824,8 +825,7 @@ namespace UnifiWebhookEventReceiverTests
                         device = "AA:BB:CC:DD:EE:FF",
                         eventId = "test-event-123",
                         deviceName = "Test Camera",
-                        originalFileName = "test_video_motion_2025-01-01_12-00-00.mp4",
-                        thumbnail = thumbnailData
+                        originalFileName = "test_video_motion_2025-01-01_12-00-00.mp4"
                     }
                 }
             };

--- a/test/coverlet.runsettings
+++ b/test/coverlet.runsettings
@@ -5,13 +5,15 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>opencover</Format>
+          <Format>cobertura</Format>
           <Exclude>[xunit*]*,[*.Tests*]*,[*]*.Program,[*]*Exception</Exclude>
-          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute,ExcludeFromCoverageAttribute</ExcludeByAttribute>
           <ExcludeByFile>**/bin/**/*,**/obj/**/*</ExcludeByFile>
           <IncludeTestAssembly>false</IncludeTestAssembly>
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>
           <IncludeDirectory>../src/</IncludeDirectory>
+          <SkipAutoProps>true</SkipAutoProps>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
Introduces a custom ExcludeFromCoverageAttribute and LoggerExtensions to allow exclusion of logging and other code from coverage reports. Adds thumbnail property to Event and Alarm models, updates AlarmProcessingService and S3StorageService to handle thumbnail data, and adjusts tests accordingly. Updates coverlet.runsettings to recognize the new attribute and output cobertura format.