### PR TITLE
Detect missing video files across UTC folders

### DIFF
--- a/summary-event-lambda/test/index.test.js
+++ b/summary-event-lambda/test/index.test.js
@@ -204,10 +204,12 @@ describe('summary-event-lambda', () => {
         
         // Verify the S3 operations were called as expected
         const s3Calls = S3Client.prototype.send.mock.calls;
-        expect(s3Calls.length).toBe(3); // GetObject, ListObjects, PutObject
+        expect(s3Calls.length).toBe(5); // GetObject, ListObjects (missing videos), ListObjects (UTC folder 1), ListObjects (UTC folder 2), PutObject
         expect(s3Calls[0][0]).toBeInstanceOf(GetObjectCommand);
         expect(s3Calls[1][0]).toBeInstanceOf(ListObjectsV2Command);
-        expect(s3Calls[2][0]).toBeInstanceOf(PutObjectCommand);
+        expect(s3Calls[2][0]).toBeInstanceOf(ListObjectsV2Command);
+        expect(s3Calls[3][0]).toBeInstanceOf(ListObjectsV2Command);
+        expect(s3Calls[4][0]).toBeInstanceOf(PutObjectCommand);
         
         // Verify the SQS operations were called as expected
         const sqsCalls = SQSClient.prototype.send.mock.calls;


### PR DESCRIPTION
Added logic to identify JSON metadata files without corresponding video files by scanning relevant UTC date folders that overlap with the target Eastern date. Updated tests to account for additional S3 ListObjectsV2 calls when checking multiple UTC folders.