### PR TITLE
Added missing video list to summary response

### DIFF
--- a/src/UnifiWebhookEventHandler.cs
+++ b/src/UnifiWebhookEventHandler.cs
@@ -13,14 +13,10 @@ using System.Net;
 using System.Reflection;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
-using Amazon.S3;
-using Amazon.SecretsManager;
-using Amazon.SQS;
 using Newtonsoft.Json;
 using UnifiWebhookEventReceiver.Configuration;
 using UnifiWebhookEventReceiver.Infrastructure;
 using UnifiWebhookEventReceiver.Services;
-using UnifiWebhookEventReceiver.Services.Implementations;
 
 // Assembly attributes
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
This pull request updates the event summary endpoint to improve how missing video events are reported and cleans up related code. The main changes include replacing the legacy `missing` field with new `missingVideoEvents` and `missingVideoCount` fields in the summary response, updating the logic for collecting missing video events, and adding tests to verify the new behavior.

**API Response and Data Model Updates:**

* The summary response now includes `missingVideoEvents` (an array of missing video event objects) and `missingVideoCount` (the count), and removes the legacy `missing` field. The summary message now also mentions missing videos when applicable. [[1]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L150-R159) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R430-R450)
* The `SummaryDataResult` model and related logic have been updated to use `missingVideoEvents` instead of the old `missingEvents`/`missing` field. [[1]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L186-R186) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L253-R259) [[3]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L460-R474)

**Business Logic Changes:**

* The process for collecting missing video events has been refactored: only events with a valid presigned URL are added to the camera's events, and missing video events are now tracked separately based on summary file data. [[1]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60R212-R217) [[2]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L234-R240) [[3]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L305-R312) [[4]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L331-R336) [[5]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L340-R346) [[6]](diffhunk://#diff-bb4ce758fbba772ca65e5801505f86ce2ab48e109c2a7e871ef9e5c7fc805a60L380-R403)

**Testing Improvements:**

* New tests verify that the summary response includes the new `missingVideoEvents` and `missingVideoCount` fields, omits the legacy `missing` field, and that the summary message includes missing video information as expected.

**Code Cleanup:**

* Unused using statements and references were removed from `UnifiWebhookEventHandler.cs`.