### PR TITLE
Update SQS retention and S3 transition policies

### DIFF
--- a/templates/api-cf-stack.yaml
+++ b/templates/api-cf-stack.yaml
@@ -178,7 +178,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub "${FunctionName}-summary-event-dlq"
-      MessageRetentionPeriod: 1209600
+      MessageRetentionPeriod: 86400  # 1 day
       Tags:
         - Key: "Name"
           Value: !Sub "${FunctionName}-summary-event-dlq"
@@ -447,9 +447,9 @@ Resources:
         Rules:
           - Id: TransitionToOneZoneIA
             Status: Enabled
-            # Transition to One Zone-IA after 1 day for immediate cost savings
+            # Transition to One Zone-IA after 30 days (minimum required by AWS)
             Transitions:
-              - TransitionInDays: 1
+              - TransitionInDays: 30
                 StorageClass: ONEZONE_IA
           - Id: DeleteAfter30Days
             Status: Enabled
@@ -482,7 +482,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub "${FunctionName}-alarm-processing-dlq"
-      MessageRetentionPeriod: 1209600  # 14 days
+      MessageRetentionPeriod: 86400  # 1 day
       Tags:
         - Key: "Name"
           Value: !Sub "${FunctionName}-alarm-processing-dlq"


### PR DESCRIPTION
Reduced SQS dead-letter queue message retention from 14 days to 1 day for summary-event and alarm-processing queues. Adjusted S3 lifecycle transition to One Zone-IA from 1 day to 30 days to comply with AWS minimum requirements.