### PR TITLE
Increase Lambda function timeout to 240 seconds

### DIFF
--- a/aws-lambda-tools-defaults.json
+++ b/aws-lambda-tools-defaults.json
@@ -10,6 +10,6 @@
     "configuration": "Release",
     "function-runtime": "dotnet8",
     "function-memory-size": 128,
-    "function-timeout": 30,
+    "function-timeout": 240,
     "function-handler": "Code::Code.Function::FunctionHandler"
 }

--- a/templates/api-cf-stack.yaml
+++ b/templates/api-cf-stack.yaml
@@ -722,7 +722,7 @@ Resources:
               #AssemblyName::NameSpace.ClassName::FunctionHandlerName
       Handler: UnifiWebhookEventReceiver::UnifiWebhookEventReceiver.UnifiWebhookEventHandler::FunctionHandler
       MemorySize: 1536
-      Timeout: 180
+      Timeout: 240
       Runtime: dotnet10
       Role: !GetAtt LambdaRole.Arn
       Environment:


### PR DESCRIPTION
Updated the timeout setting for Lambda functions in both aws-lambda-tools-defaults.json and api-cf-stack.yaml from 30/180 seconds to 240 seconds to allow for longer execution times.