### PR TITLE
Increase max video download wait time

### DIFF
--- a/src/Services/Implementations/UnifiProtectService.cs
+++ b/src/Services/Implementations/UnifiProtectService.cs
@@ -35,7 +35,7 @@ namespace UnifiWebhookEventReceiver.Services.Implementations
         /// <summary>
         /// Maximum time in seconds to wait for video download to complete
         /// </summary>
-        private const int MaxVideoDownloadWaitTimeSeconds = 118;
+        private const int MaxVideoDownloadWaitTimeSeconds = 180;
 
         /// <summary>
         /// Initializes a new instance of the UnifiProtectService.


### PR DESCRIPTION
Raise MaxVideoDownloadWaitTimeSeconds from 118 to 180 in UnifiProtectService to allow more time for video downloads under slower network conditions and reduce premature timeout failures.